### PR TITLE
Ensure resolv.conf.save is absent if modifying DNS

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,11 @@ define network_if_base (
     }
   }
 
+  file { 'resolv.conf.save':
+    ensure => 'absent',
+    path   => '/etc/resolv.conf.save', 
+  }
+
   case $ensure {
     up: {
       exec { "ifup-$interface":


### PR DESCRIPTION
Workaround a (documented) behaviour of NetworkManager that will trash the resolv.conf file with its backup.
The workaround just ensure that the file is absent.
