### PR TITLE
Make the macaddress argument to network::if::dynamic and network::if::st...

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,6 +7,7 @@ project_page 'https://github.com/razorsedge/puppet-network'
 source 'git://github.com/razorsedge/puppet-network.git'
 summary 'Puppet module to manage RedHat/Fedora traditional network configuration.'
 description 'This module manages Red Hat/Fedora traditional network configuration.
+dependency 'puppetlabs/stdlib', '>= 0.1.7'
 
 It allows for static, dhcp, and bootp configuration of normal and bonded interfaces.  There is support for aliases on normal and bonded interfaces.  It can configure static routes.  It can configure MTU, ETHTOOL_OPTS, and BONDING_OPTS on a per-interface basis.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Normal interface - static (minimal):
     network::if::static { "eth0":
       ipaddress  => "1.2.3.248",
       netmask    => "255.255.255.128",
-      macaddress => $macaddress_eth0,
       ensure     => "up",
     }
 
@@ -49,7 +48,6 @@ Normal interface - static:
 Normal interface - dhcp (minimal):
 
     network::if::dynamic { "eth2":
-      macaddress => $macaddress_eth2,
       ensure     => "up",
     }
 

--- a/manifests/if/dynamic.pp
+++ b/manifests/if/dynamic.pp
@@ -3,7 +3,7 @@
 # Creates a normal interface with dynamic IP information.
 #
 # Parameters:
-#   $macaddress   - required
+#   $macaddress   - optional - defaults to macaddress_$title
 #   $bootproto    - optional - defaults to "dhcp"
 #   $mtu          - optional
 #   $ethtool_opts - optional
@@ -28,12 +28,17 @@
 #  }
 #
 define network::if::dynamic (
-  $macaddress,
+  $macaddress = "",
   $bootproto = "dhcp",
   $mtu = "",
   $ethtool_opts = "",
   $ensure
 ) {
+
+  if ! $macaddress {
+    $macaddress = getvar("macaddress_$title")
+  }
+
   network_if_base { "$title":
     ipaddress    => "",
     netmask      => "",

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -6,7 +6,7 @@
 #   $ipaddress    - required
 #   $netmask      - required
 #   $gateway      - optional
-#   $macaddress   - required
+#   $macaddress   - optional - defaults to macaddress_$title
 #   $mtu          - optional
 #   $ethtool_opts - optional
 #   $peerdns      - optional
@@ -33,7 +33,7 @@ define network::if::static (
   $ipaddress,
   $netmask,
   $gateway = "",
-  $macaddress,
+  $macaddress = "",
   $mtu = "",
   $ethtool_opts = "",
   $peerdns = "",
@@ -42,6 +42,11 @@ define network::if::static (
   $domain = "",
   $ensure
 ) {
+
+  if ! $macaddress {
+    $macaddress = getvar("macaddress_$title")
+  }
+
   network_if_base { "$title":
     ipaddress    => $ipaddress,
     netmask      => $netmask,


### PR DESCRIPTION
...atic

optional.  In additional to removing the need in most cases for an extra
argument, it also makes it possible to operate on lists of inetfaces.  eg.

  $unused_interfaces = delete(delete(split($interfaces, ','), 'lo'), 'eth4')

  network::if::dynamic { $unused_interfaces:
    ensure       => "down",
  }

Introduces a dependency on puppetlabs/stdlib >= 0.1.7.

Removes the useless branches and peerdns argument fix per:

https://github.com/razorsedge/puppet-network/pull/6/
