### PR TITLE
cleaned up to conform to style guide via puppet-lint --no-only_variable_...

### DIFF
--- a/manifests/bond/alias.pp
+++ b/manifests/bond/alias.pp
@@ -22,21 +22,21 @@
 #  }
 #
 define network::bond::alias (
+  $ensure,
   $ipaddress,
   $netmask,
-  $gateway = "",
-  $ensure
-) {
-  network_if_base { "$title":
+  $gateway = ''
+  ) {
+  network_if_base { "${title}":
+    ensure       => $ensure,
     ipaddress    => $ipaddress,
     netmask      => $netmask,
     gateway      => $gateway,
-    macaddress   => "",
-    bootproto    => "none",
-    mtu          => "",
-    ethtool_opts => "",
-    bonding_opts => "",
+    macaddress   => '',
+    bootproto    => 'none',
+    mtu          => '',
+    ethtool_opts => '',
+    bonding_opts => '',
     isalias      => true,
-    ensure       => $ensure,
-  }
+    }
 } # define network::bond::alias

--- a/manifests/bond/dynamic.pp
+++ b/manifests/bond/dynamic.pp
@@ -21,31 +21,33 @@
 #  }
 #
 define network::bond::dynamic (
-  $mtu = "",
-  $ethtool_opts = "",
-  $bonding_opts = "",
-  $ensure
-) {
-  network_if_base { "$title":
-    ipaddress    => "",
-    netmask      => "",
-    gateway      => "",
-    macaddress   => "",
-    bootproto    => "dhcp",
+  $ensure,
+  $mtu = '',
+  $ethtool_opts = '',
+  $bonding_opts = '',
+  ) {
+  network_if_base { "${title}":
+    ensure       => $ensure,
+    ipaddress    => '',
+    netmask      => '',
+    gateway      => '',
+    macaddress   => '',
+    bootproto    => 'dhcp',
     mtu          => $mtu,
     ethtool_opts => $ethtool_opts,
     bonding_opts => $bonding_opts,
-    ensure       => $ensure,
   }
 
-  augeas { "modprobe.conf_$title":
-    context => "/files/etc/modprobe.conf",
-    changes => [ "set alias[last()+1] $title", "set alias[last()]/modulename bonding", ],
-    onlyif  => "match alias[*][. = '$title'] size == 0",
-   #onlyif  => "match */modulename[. = 'bonding'] size == 0",
-    before  => $ensure ? {
-      up   => Exec["ifup-$title"],
-      down => Exec["ifdown-$title"],
+  $ifstate = $ensure ? {
+      up   => Exec["ifup-${title}"],
+      down => Exec["ifdown-${title}"],
     }
+
+  augeas { "modprobe.conf_${title}":
+    context => '/files/etc/modprobe.conf',
+    changes => [ "set alias[last()+1] ${title}", 'set alias[last()]/modulename bonding', ],
+    onlyif  => "match alias[*][. = '${title}'] size == 0",
+    #onlyif  => "match */modulename[. = 'bonding'] size == 0",
+    before  => $ifstate,
   }
 } # define network::bond::dynamic

--- a/manifests/bond/slave.pp
+++ b/manifests/bond/slave.pp
@@ -21,18 +21,18 @@
 define network::bond::slave (
   $macaddress,
   $master,
-  $ethtool_opts = ""
+  $ethtool_opts = ''
 ) {
   $interface = $name
 
-  file { "ifcfg-$interface":
-    mode    => "644",
-    owner   => "root",
-    group   => "root",
-    ensure  => "present",
-    path    => "/etc/sysconfig/network-scripts/ifcfg-$interface",
-    content => template("network/ifcfg-bond.erb"),
-    before  => File["ifcfg-$master"],
+  file { "ifcfg-${interface}":
+    ensure  => 'present',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}",
+    content => template('network/ifcfg-bond.erb'),
+    before  => File["ifcfg-${master}"],
     # need to know $ensure since one of these execs is not defined.
     #notify  => [ Exec["ifup-$master"], Exec["ifdown-$master"], ],
   }

--- a/manifests/bond/static.pp
+++ b/manifests/bond/static.pp
@@ -26,34 +26,36 @@
 #  }
 #
 define network::bond::static (
+  $ensure,
   $ipaddress,
   $netmask,
-  $gateway = "",
-  $mtu = "",
-  $ethtool_opts = "",
-  $bonding_opts = "",
-  $ensure
-) {
-  network_if_base { "$title":
+  $gateway = '',
+  $mtu = '',
+  $ethtool_opts = '',
+  $bonding_opts = '',
+  ) {
+  network_if_base { "${title}":
+    ensure       => $ensure,
     ipaddress    => $ipaddress,
     netmask      => $netmask,
     gateway      => $gateway,
-    macaddress   => "",
-    bootproto    => "none",
+    macaddress   => '',
+    bootproto    => 'none',
     mtu          => $mtu,
     ethtool_opts => $ethtool_opts,
     bonding_opts => $bonding_opts,
-    ensure       => $ensure,
   }
 
-  augeas { "modprobe.conf_$title":
-    context => "/files/etc/modprobe.conf",
-    changes => [ "set alias[last()+1] $title", "set alias[last()]/modulename bonding", ],
-    onlyif  => "match alias[*][. = '$title'] size == 0",
-   #onlyif  => "match */modulename[. = 'bonding'] size == 0",
-    before  => $ensure ? {
-      up   => Exec["ifup-$title"],
-      down => Exec["ifdown-$title"],
+  $ifstate = $ensure ? {
+      up   => Exec["ifup-${title}"],
+      down => Exec["ifdown-${title}"],
     }
+
+  augeas { "modprobe.conf_${title}":
+    context => '/files/etc/modprobe.conf',
+    changes => [ "set alias[last()+1] ${title}", 'set alias[last()]/modulename bonding', ],
+    onlyif  => "match alias[*][. = '${title}'] size == 0",
+    #onlyif  => "match */modulename[. = 'bonding'] size == 0",
+    before  => $ifstate,
   }
 } # define network::bond::static

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -5,9 +5,9 @@
 # Parameters:
 #   $hostname   - optional - Changes the hostname (be aware that it will break something)
 #                            Note: when you'll reboot/restart puppet, it will generate a
-#                            new certificate and a new certificate request, based on the 
+#                            new certificate and a new certificate request, based on the
 #                            new hostname; you'll have to sign it (if autosign is off).
-#                            You'll also have to provide a new node definition in the 
+#                            You'll also have to provide a new node definition in the
 #                            manifest based on the new hostname.
 #   $gateway    - optional - Sets the default gateway
 #   $gatewaydev - optional - Determines the device to use as the default gateway.
@@ -36,30 +36,30 @@
 #   NETWORKING_IPV6=yes|no
 #
 define network::global (
-  $hostname = "",
-  $gateway = "",
-  $vlan = "",
-  $nozeroconf = "",
-  $gatewaydev = ""
+  $hostname = '',
+  $gateway = '',
+  $vlan = '',
+  $nozeroconf = '',
+  $gatewaydev = ''
 ) {
   $nisdomain = $::nisdomainname ? {
-    ''      => "",
-    default => "$::nisdomainname",
+    ''      => '',
+    default => $::nisdomainname,
   }
 
-  file { "network.sysconfig":
-    mode    => "644",
-    owner   => "root",
-    group   => "root",
-    ensure  => "present",
-    path    => "/etc/sysconfig/network",
-    content => template("network/network.erb"),
-    notify  => Service["network"],
+  file { 'network.sysconfig':
+    ensure  => 'present',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    path    => '/etc/sysconfig/network',
+    content => template('network/network.erb'),
+    notify  => Service['network'],
   }
 
-  service { "network":
-    name       => "network",
-    ensure     => "running",
+  service { 'network':
+    ensure     => 'running',
+    name       => 'network',
     enable     => true,
     hasrestart => true,
     hasstatus  => true,

--- a/manifests/if/alias.pp
+++ b/manifests/if/alias.pp
@@ -25,27 +25,27 @@
 #  }
 #
 define network::if::alias (
+  $ensure,
   $ipaddress,
   $netmask,
-  $gateway = "",
-  $peerdns = "",
-  $dns1 = "",
-  $dns2 = "",
-  $ensure
+  $gateway = '',
+  $peerdns = '',
+  $dns1 = '',
+  $dns2 = '',
 ) {
-  network_if_base { "$title":
+  network_if_base { "${title}":
+    ensure       => $ensure,
     ipaddress    => $ipaddress,
     netmask      => $netmask,
     gateway      => $gateway,
-    macaddress   => "",
-    bootproto    => "none",
-    mtu          => "",
-    ethtool_opts => "",
-    bonding_opts => "",
+    macaddress   => '',
+    bootproto    => 'none',
+    mtu          => '',
+    ethtool_opts => '',
+    bonding_opts => '',
     isalias      => true,
     peerdns      => $peerdns,
     dns1         => $dns1,
     dns2         => $dns2,
-    ensure       => $ensure,
   }
 } # define network::if::alias

--- a/manifests/if/dynamic.pp
+++ b/manifests/if/dynamic.pp
@@ -28,21 +28,21 @@
 #  }
 #
 define network::if::dynamic (
+  $ensure,
   $macaddress,
-  $bootproto = "dhcp",
-  $mtu = "",
-  $ethtool_opts = "",
-  $ensure
+  $bootproto = 'dhcp',
+  $mtu = '',
+  $ethtool_opts = '',
 ) {
-  network_if_base { "$title":
-    ipaddress    => "",
-    netmask      => "",
-    gateway      => "",
+  network_if_base { "${title}":
+    ensure       => $ensure,
+    ipaddress    => '',
+    netmask      => '',
+    gateway      => '',
     macaddress   => $macaddress,
     bootproto    => $bootproto,
     mtu          => $mtu,
     ethtool_opts => $ethtool_opts,
-    bonding_opts => "",
-    ensure       => $ensure,
+    bonding_opts => '',
   }
 } # define network::if::dynamic

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -30,31 +30,31 @@
 #  }
 #
 define network::if::static (
+  $ensure,
+  $macaddress,
   $ipaddress,
   $netmask,
-  $gateway = "",
-  $macaddress,
-  $mtu = "",
-  $ethtool_opts = "",
-  $peerdns = "",
-  $dns1 = "",
-  $dns2 = "",
-  $domain = "",
-  $ensure
+  $gateway = '',
+  $mtu = '',
+  $ethtool_opts = '',
+  $peerdns = '',
+  $dns1 = '',
+  $dns2 = '',
+  $domain = '',
 ) {
-  network_if_base { "$title":
+  network_if_base { "${title}":
+    ensure       => $ensure,
     ipaddress    => $ipaddress,
     netmask      => $netmask,
     gateway      => $gateway,
     macaddress   => $macaddress,
-    bootproto    => "none",
+    bootproto    => 'none',
     mtu          => $mtu,
     ethtool_opts => $ethtool_opts,
-    bonding_opts => "",
+    bonding_opts => '',
     peerdns      => $peerdns,
     dns1         => $dns1,
     dns2         => $dns2,
     domain       => $domain,
-    ensure       => $ensure,
   }
 } # define network::if::static

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@ class network {
   case $::osfamily {
     RedHat: { }
     default: {
-      fail("This network module only supports Red Hat-based systems.")
+      fail('This network module only supports Red Hat-based systems.')
     }
   }
 } # class network
@@ -58,60 +58,59 @@ class network {
 #   REORDER_HDR=yes|no
 #
 define network_if_base (
+  $ensure,
+  $macaddress,
   $ipaddress,
   $netmask,
-  $gateway = "",
-  $macaddress,
-  $bootproto = "none",
-  $mtu = "",
-  $ethtool_opts = "",
-  $bonding_opts = "",
+  $gateway = '',
+  $bootproto = 'none',
+  $mtu = '',
+  $ethtool_opts = '',
+  $bonding_opts = '',
   $isalias = false,
   $peerdns = false,
-  $dns1 = "",
-  $dns2 = "",
-  $domain = "",
-  $ensure
+  $dns1 = '',
+  $dns2 = '',
+  $domain = '',
 ) {
   $interface = $name
 
   if $isalias {
     $onparent = $ensure ? {
-      up   => "yes",
-      down => "no",
+      up   => 'yes',
+      down => 'no',
     }
+    $iftemplate = template('network/ifcfg-eth.erb')
   } else {
     $onboot = $ensure ? {
-      up   => "yes",
-      down => "no",
+      up   => 'yes',
+      down => 'no',
     }
+    $iftemplate = template('network/ifcfg-alias.erb')
   }
 
-  file { "ifcfg-$interface":
-    mode    => "644",
-    owner   => "root",
-    group   => "root",
-    ensure  => "present",
-    path    => "/etc/sysconfig/network-scripts/ifcfg-$interface",
-    content => $isalias ? {
-      false => template("network/ifcfg-eth.erb"),
-      true  => template("network/ifcfg-alias.erb"),
-    }
+  file { "ifcfg-${interface}":
+    ensure  => 'present',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}",
+    content => $iftemplate,
   }
 
   case $ensure {
-    up: {
-      exec { "ifup-$interface":
-        command     => "/sbin/ifdown $interface; /sbin/ifup $interface",
-        subscribe   => File["ifcfg-$interface"],
+    default,up: {
+      exec { "ifup-${interface}":
+        command     => "/sbin/ifdown ${interface}; /sbin/ifup ${interface}",
+        subscribe   => File["ifcfg-${interface}"],
         refreshonly => true,
       }
     }
 
     down: {
-      exec { "ifdown-$interface":
-        command     => "/sbin/ifdown $interface",
-        subscribe   => File["ifcfg-$interface"],
+      exec { "ifdown-${interface}":
+        command     => "/sbin/ifdown ${interface}",
+        subscribe   => File["ifcfg-${interface}"],
         refreshonly => true,
       }
     }

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -27,14 +27,14 @@ define network::route (
 ) {
   $interface = $name
 
-  file { "route-$interface":
-    mode    => "644",
-    owner   => "root",
-    group   => "root",
-    ensure  => "present",
-    path    => "/etc/sysconfig/network-scripts/route-$interface",
-    content => template("network/route-eth.erb"),
-    before  => File["ifcfg-$interface"],
+  file { "route-${interface}":
+    ensure  => 'present',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    path    => "/etc/sysconfig/network-scripts/route-${interface}",
+    content => template('network/route-eth.erb'),
+    before  => File["ifcfg-${interface}"],
     # TODO: need to know $ensure of $interface since one of these execs is not defined.
     #notify  => [ Exec["ifup-$interface"], Exec["ifdown-$interface"], ],
   }

--- a/tests/bond-alias.pp
+++ b/tests/bond-alias.pp
@@ -1,10 +1,10 @@
 include network
 
 # aliased bonded interface
-network::bond::alias { "bond2:1":
-  ipaddress => "1.2.3.6",
-  netmask   => "255.255.255.0",
- #gateway   => "1.2.3.1",
-  ensure    => "up",
+network::bond::alias { 'bond2:1':
+  ensure    => 'up',
+  ipaddress => '1.2.3.6',
+  netmask   => '255.255.255.0',
+  #gateway   => '1.2.3.1',
 }
 

--- a/tests/bond-dhcp.pp
+++ b/tests/bond-dhcp.pp
@@ -10,10 +10,10 @@ include network
 #}
 
 # bonded master interface - dhcp
-network::bond::dynamic { "bond2":
-  mtu          => "9000",
-  ethtool_opts => "speed 1000 duplex full autoneg off",
-  bonding_opts => "mode=active-backup arp_interval=60 arp_ip_target=192.168.1.254",
-  ensure       => "up",
+network::bond::dynamic { 'bond2':
+  ensure       => 'up',
+  mtu          => '9000',
+  ethtool_opts => 'speed 1000 duplex full autoneg off',
+  bonding_opts => 'mode=active-backup arp_interval=60 arp_ip_target=192.168.1.254',
 }
 

--- a/tests/bond-static.pp
+++ b/tests/bond-static.pp
@@ -13,26 +13,26 @@ include network
 #}
 
 # bonded master interface - static
-network::bond::static { "bond0":
-  ipaddress    => "1.2.3.5",
-  netmask      => "255.255.255.0",
-  gateway      => "1.2.3.1",
-  mtu          => "9000",
-  bonding_opts => "mode=active-backup miimon=100",
-  ensure       => "up",
+network::bond::static { 'bond0':
+  ensure       => 'up',
+  ipaddress    => '1.2.3.5',
+  netmask      => '255.255.255.0',
+  gateway      => '1.2.3.1',
+  mtu          => '9000',
+  bonding_opts => 'mode=active-backup miimon=100',
 }
 
 # bonded slave interface - static
-network::bond::slave { "eth1":
+network::bond::slave { 'eth1':
   macaddress   => $::macaddress_eth1,
-  ethtool_opts => "speed 1000 duplex full autoneg off",
-  master       => "bond0",
+  ethtool_opts => 'speed 1000 duplex full autoneg off',
+  master       => 'bond0',
 }
 
 # bonded slave interface - static
-network::bond::slave { "eth3":
+network::bond::slave { 'eth3':
   macaddress   => $::macaddress_eth3,
-  ethtool_opts => "speed 100 duplex half autoneg off",
-  master       => "bond0",
+  ethtool_opts => 'speed 100 duplex half autoneg off',
+  master       => 'bond0',
 }
 

--- a/tests/if-alias.pp
+++ b/tests/if-alias.pp
@@ -1,10 +1,10 @@
 include network
 
 # aliased interface
-network::if::alias { "eth99:1":
-  ipaddress => "1.2.3.99",
-  netmask   => "255.255.255.0",
- #gateway   => "1.2.3.1",
-  ensure    => "up",
+network::if::alias { 'eth99:1':
+  ensure    => 'up',
+  ipaddress => '1.2.3.99',
+  netmask   => '255.255.255.0',
+  #gateway   => '1.2.3.1',
 }
 

--- a/tests/if-bootp.pp
+++ b/tests/if-bootp.pp
@@ -1,11 +1,11 @@
 include network
 
 # normal interface - bootp
-network::if::dynamic { "eth99":
-  macaddress   => "ef:ef:ef:ef:ef:ef",
-  bootproto    => "bootp",
-  mtu          => "1500",
-  ethtool_opts => "speed 100 duplex full autoneg off",
-  ensure       => "up",
+network::if::dynamic { 'eth99':
+  ensure       => 'up',
+  macaddress   => 'ef:ef:ef:ef:ef:ef',
+  bootproto    => 'bootp',
+  mtu          => '1500',
+  ethtool_opts => 'speed 100 duplex full autoneg off',
 }
 

--- a/tests/if-dhcp.pp
+++ b/tests/if-dhcp.pp
@@ -1,10 +1,10 @@
 include network
 
 # normal interface - dhcp
-network::if::dynamic { "eth99":
-  macaddress   => "ff:aa:ff:aa:ff:aa",
-  mtu          => "1500",
-  ethtool_opts => "speed 100 duplex full autoneg off",
-  ensure       => "up",
+network::if::dynamic { 'eth99':
+  ensure       => 'up',
+  macaddress   => 'ff:aa:ff:aa:ff:aa',
+  mtu          => '1500',
+  ethtool_opts => 'speed 100 duplex full autoneg off',
 }
 

--- a/tests/if-multiple.pp
+++ b/tests/if-multiple.pp
@@ -1,19 +1,19 @@
 include network
 
 # normal interface - dhcp
-network::if::dynamic { "eth70":
-  macaddress => "ff:ff:ff:ff:ff:ff",
-  ensure => "up",
+network::if::dynamic { 'eth70':
+  ensure     => 'up',
+  macaddress => 'ff:ff:ff:ff:ff:ff',
 }
 
 # normal interface - static
-network::if::static { "eth90":
-  ipaddress => "1.2.3.4",
-  netmask => "255.255.255.0",
-  gateway => "1.2.3.1",
-  macaddress => "fe:fe:fe:ff:ff:ff",
-  mtu => "9000",
-  ethtool_opts => "speed 10 duplex half autoneg off",
-  ensure => "up",
+network::if::static { 'eth90':
+  ensure       => 'up',
+  ipaddress    => '1.2.3.4',
+  netmask      => '255.255.255.0',
+  gateway      => '1.2.3.1',
+  macaddress   => 'fe:fe:fe:ff:ff:ff',
+  mtu          => '9000',
+  ethtool_opts => 'speed 10 duplex half autoneg off',
 }
 

--- a/tests/if-static.pp
+++ b/tests/if-static.pp
@@ -1,13 +1,13 @@
 include network
 
 # normal interface - static
-network::if::static { "eth1":
-  ipaddress    => "1.2.3.4",
-  netmask      => "255.255.255.0",
-  gateway      => "1.2.3.1",
-  macaddress   => "fe:fe:fe:aa:aa:aa",
-  mtu          => "9000",
-  ethtool_opts => "speed 1000 duplex full autoneg off",
-  ensure       => "up",
+network::if::static { 'eth1':
+  ensure       => 'up',
+  ipaddress    => '1.2.3.4',
+  netmask      => '255.255.255.0',
+  gateway      => '1.2.3.1',
+  macaddress   => 'fe:fe:fe:aa:aa:aa',
+  mtu          => '9000',
+  ethtool_opts => 'speed 1000 duplex full autoneg off',
 }
 

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,9 +1,9 @@
 include network
 
-network::global { "default":
-  gateway    => "1.2.3.1",
-  gatewaydev => "eth0",
-  vlan       => "yes",
-  nozeroconf => "yes",
+network::global { 'default':
+  gateway    => '1.2.3.1',
+  gatewaydev => 'eth0',
+  vlan       => 'yes',
+  nozeroconf => 'yes',
 }
 

--- a/tests/route.pp
+++ b/tests/route.pp
@@ -1,14 +1,14 @@
 include network
 
 # interface routes
-network::route { "eth2":
-  address => [ "192.168.2.0", "10.0.0.0", ],
-  netmask => [ "255.255.255.0", "255.0.0.0", ],
-  gateway => [ "192.168.1.1", "10.0.0.1", ],
+network::route { 'eth2':
+  address => [ '192.168.2.0', '10.0.0.0', ],
+  netmask => [ '255.255.255.0', '255.0.0.0', ],
+  gateway => [ '192.168.1.1', '10.0.0.1', ],
 }
 
-network::if::dynamic { "eth2":
+network::if::dynamic { 'eth2':
+  ensure       => 'down',
   macaddress   => $::macaddress_eth2,
-  ensure       => "down",
 }
 


### PR DESCRIPTION
...string-check

Actually, I turned off a few checks.
--no-autoloader_layout-check
--no-80chars-check
--no-only_variable_string_check

I did NOT run this against the rspec tests but I don't think I broke anything, every .pp file passes puppet parser validate on 2.7.19.

This should make most everything conform to the style guide at http://docs.puppetlabs.com/guides/style_guide.html.

The only thing I really had a question about was things like:
  network_if_base { "${title}":

That looks right to me but the linter complains about quoting only a variable.   If you wanted to fix those up, there are only 6 of them.

./manifests/bond/alias.pp - WARNING: string containing only a variable on line 30
./manifests/bond/dynamic.pp - WARNING: string containing only a variable on line 29
./manifests/bond/static.pp - WARNING: string containing only a variable on line 37
./manifests/if/alias.pp - WARNING: string containing only a variable on line 36
./manifests/if/dynamic.pp - WARNING: string containing only a variable on line 37
./manifests/if/static.pp - WARNING: string containing only a variable on line 45

We're using this module and it's making our git pre-commit hook check go nuts, that's why we wanted to clean it up.   Hope you find it useful.  

Let me know if you have any questions/concerns or if you need me to fix/change/explain something.

Cheers,

-Dave
