### PR TITLE
Fixed ERB template deprecation warnings

### DIFF
--- a/templates/ifcfg-alias.erb
+++ b/templates/ifcfg-alias.erb
@@ -1,16 +1,16 @@
 ###
 ### File managed by Puppet
 ###
-DEVICE=<%= interface %>
-BOOTPROTO=<%= bootproto %>
-ONPARENT=<%= onparent %>
+DEVICE=<%= @interface %>
+BOOTPROTO=<%= @bootproto %>
+ONPARENT=<%= @onparent %>
 TYPE=Ethernet
-<% if !ipaddress.empty? %>IPADDR=<%= ipaddress %>
+<% if !@ipaddress.empty? %>IPADDR=<%= @ipaddress %>
 <% end -%>
-<% if !netmask.empty? %>NETMASK=<%= netmask %>
+<% if !@netmask.empty? %>NETMASK=<%= @netmask %>
 <% end -%>
-<% if !gateway.empty? %>GATEWAY=<%= gateway %>
+<% if !@gateway.empty? %>GATEWAY=<%= @gateway %>
 <% end -%>
-<% if userctl %>USERCTL=yes
+<% if @userctl %>USERCTL=yes
 <% end -%>
 NM_CONTROLLED=no

--- a/templates/ifcfg-bond.erb
+++ b/templates/ifcfg-bond.erb
@@ -1,11 +1,11 @@
 ###
 ### File managed by Puppet
 ###
-DEVICE=<%= interface %>
-HWADDR=<%= macaddress %>
-MASTER=<%= master %>
+DEVICE=<%= @interface %>
+HWADDR=<%= @macaddress %>
+MASTER=<%= @master %>
 SLAVE=yes
 TYPE=Ethernet
-<% if !ethtool_opts.empty? %>ETHTOOL_OPTS="<%= ethtool_opts %>"
+<% if !@ethtool_opts.empty? %>ETHTOOL_OPTS="<%= @ethtool_opts %>"
 <% end -%>
 NM_CONTROLLED=no

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -1,34 +1,34 @@
 ###
 ### File managed by Puppet
 ###
-DEVICE=<%= interface %>
-BOOTPROTO=<%= bootproto %>
-<% if !macaddress.empty? %>HWADDR=<%= macaddress %>
+DEVICE=<%= @interface %>
+BOOTPROTO=<%= @bootproto %>
+<% if !@macaddress.empty? %>HWADDR=<%= @macaddress %>
 <% end -%>
-ONBOOT=<%= onboot %>
-HOTPLUG=<%= onboot %>
+ONBOOT=<%= @onboot %>
+HOTPLUG=<%= @onboot %>
 TYPE=Ethernet
-<% if !ipaddress.empty? %>IPADDR=<%= ipaddress %>
+<% if !@ipaddress.empty? %>IPADDR=<%= @ipaddress %>
 <% end -%>
-<% if !netmask.empty? %>NETMASK=<%= netmask %>
+<% if !@netmask.empty? %>NETMASK=<%= @netmask %>
 <% end -%>
-<% if !gateway.empty? %>GATEWAY=<%= gateway %>
+<% if !@gateway.empty? %>GATEWAY=<%= @gateway %>
 <% end -%>
-<% if !mtu.empty? %>MTU=<%= mtu %>
+<% if !@mtu.empty? %>MTU=<%= @mtu %>
 <% end -%>
 <% if @bonding_opts %>BONDING_OPTS="<%= @bonding_opts %>"
 <% end -%>
-<% if !ethtool_opts.empty? %>ETHTOOL_OPTS="<%= ethtool_opts %>"
+<% if !@ethtool_opts.empty? %>ETHTOOL_OPTS="<%= @ethtool_opts %>"
 <% end -%>
-<% if !peerdns %>PEERDNS=no
+<% if !@peerdns %>PEERDNS=no
 <% else %>PEERDNS=yes
-<% if !dns1_real.empty? %>DNS1=<%= dns1_real %>
+<% if !@dns1_real.empty? %>DNS1=<%= @dns1_real %>
 <% end -%>
-<% if !dns2_real.empty? %>DNS2=<%= dns2_real %>
+<% if !@dns2_real.empty? %>DNS2=<%= @dns2_real %>
 <% end -%>
-<% if !domain.empty? %>DOMAIN="<%= domain %>"
+<% if !@domain.empty? %>DOMAIN="<%= @domain %>"
 <% end -%>
 <% end -%>
-<% if userctl %>USERCTL=yes
+<% if @userctl %>USERCTL=yes
 <% end -%>
 NM_CONTROLLED=no

--- a/templates/network.erb
+++ b/templates/network.erb
@@ -3,16 +3,16 @@
 ###
 NETWORKING=yes
 NETWORKING_IPV6=no
-<% if !hostname.empty? %>HOSTNAME=<%= hostname %>
+<% if !@hostname.empty? %>HOSTNAME=<%= @hostname %>
 <% else %>HOSTNAME=<%= fqdn %>
 <% end -%>
-<% if !gateway.empty? %>GATEWAY=<%= gateway %>
+<% if !@gateway.empty? %>GATEWAY=<%= @gateway %>
 <% end -%>
-<% if !gatewaydev.empty? %>GATEWAYDEV=<%= gatewaydev %>
+<% if !@gatewaydev.empty? %>GATEWAYDEV=<%= @gatewaydev %>
 <% end -%>
-<% if !nisdomain.empty? %>NISDOMAIN=<%= nisdomain %>
+<% if !@nisdomain.empty? %>NISDOMAIN=<%= @nisdomain %>
 <% end -%>
-<% if !vlan.empty? %>VLAN=<%= vlan %>
+<% if !@vlan.empty? %>VLAN=<%= @vlan %>
 <% end -%>
-<% if !nozeroconf.empty? %>NOZEROCONF=<%= nozeroconf %>
+<% if !@nozeroconf.empty? %>NOZEROCONF=<%= @nozeroconf %>
 <% end -%>

--- a/templates/route-eth.erb
+++ b/templates/route-eth.erb
@@ -1,12 +1,12 @@
 ###
 ### File managed by Puppet
 ###
-<% num = 0; ipaddress.each do |addr| -%>
+<% num = 0; @ipaddress.each do |addr| -%>
 ADDRESS<%= num %>=<%= addr %>
 <% num += 1; end -%>
-<% num = 0; netmask.each do |mask| -%>
+<% num = 0; @netmask.each do |mask| -%>
 NETMASK<%= num %>=<%= mask %>
 <% num += 1; end -%>
-<% num = 0; gateway.each do |gw| -%>
+<% num = 0; @gateway.each do |gw| -%>
 GATEWAY<%= num %>=<%= gw %>
 <% num += 1; end -%>


### PR DESCRIPTION
In recent Puppet versions, ERB templates give deprecation warnings, e.g.

```
Warning: Variable access via 'interface' is deprecated. Use '@interface' instead. template[/tmp/vagrant-puppet/modules-0/network/templates/ifcfg-eth.erb]:4
   (at /tmp/vagrant-puppet/modules-0/network/templates/ifcfg-eth.erb:4:in `result')
```

These are now fixed
