### PR TITLE
Adds support for specifying ipv6 networking support in the global network config

### DIFF
--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -57,7 +57,8 @@ class network::global (
   $gatewaydev = '',
   $nisdomain  = '',
   $vlan       = '',
-  $nozeroconf = ''
+  $nozeroconf = '',
+  $ipv6       = 'no'
 ) {
   # Validate our data
   if $gateway != '' {
@@ -67,6 +68,10 @@ class network::global (
   if $vlan != '' {
     $states = [ '^yes$', '^no$' ]
     validate_re($vlan, $states, '$vlan must be either "yes" or "no".')
+  }
+  # Validate ipv6 vavlues
+  if ($ipv6 != 'no') and ($ipv6 != 'yes') {
+    fail('ipv6 must be either "yes" or "no".')
   }
 
   include 'network'

--- a/spec/classes/network_global_spec.rb
+++ b/spec/classes/network_global_spec.rb
@@ -49,6 +49,7 @@ describe 'network::global', :type => 'class' do
       :nisdomain  => 'myNisDomain',
       :vlan       => 'yes',
       :nozeroconf => 'yes',
+      :ipv6       => 'yes',
     }
     end
     let :facts do {
@@ -59,7 +60,7 @@ describe 'network::global', :type => 'class' do
     it 'should contain File[network.sysconfig] with correct contents' do
       verify_contents(subject, 'network.sysconfig', [
         'NETWORKING=yes',
-        'NETWORKING_IPV6=no',
+        'NETWORKING_IPV6=yes',
         'HOSTNAME=myHostname',
         'GATEWAY=1.2.3.4',
         'GATEWAYDEV=eth2',
@@ -89,6 +90,16 @@ describe 'network::global', :type => 'class' do
       it 'should fail' do
         expect {
           should raise_error(Puppet::Error, /$vlan must be either "yes" or "no"./)
+        }
+      end
+    end
+
+    context 'ipv6 = foo' do
+      let(:params) {{ :ipv6 => 'foo' }}
+
+      it 'should fail' do
+        expect {
+          should raise_error(Puppet::Error, /$ipv6 must be either "yes" or "no"./)
         }
       end
     end

--- a/templates/network.erb
+++ b/templates/network.erb
@@ -2,7 +2,7 @@
 ### File managed by Puppet
 ###
 NETWORKING=yes
-NETWORKING_IPV6=no
+NETWORKING_IPV6=<%= ipv6 %>
 <% if !@hostname.empty? %>HOSTNAME=<%= @hostname %>
 <% else %>HOSTNAME=<%= fqdn %>
 <% end -%>


### PR DESCRIPTION
Adds some simple support in the global configuration to specify `NETWORKING_IPV6` in /etc/sysconfig/network