### PR TITLE
set default mac address for bond::slave resource if none provided

### DIFF
--- a/manifests/bond/slave.pp
+++ b/manifests/bond/slave.pp
@@ -32,7 +32,7 @@
 # Copyright (C) 2011 Mike Arnold, unless otherwise noted.
 #
 define network::bond::slave (
-  $macaddress,
+  $macaddress = '',
   $master,
   $ethtool_opts = ''
 ) {


### PR DESCRIPTION
As discussed in https://github.com/razorsedge/puppet-network/issues/34. PR to set the mac address automatically from the macaddress_ethX facts if not provided.
