### PR TITLE
Updated to use correct variable name

### DIFF
--- a/templates/ifcfg-bond.erb
+++ b/templates/ifcfg-bond.erb
@@ -2,7 +2,7 @@
 ### File managed by Puppet
 ###
 DEVICE=<%= @interface %>
-HWADDR=<%= @macaddress %>
+HWADDR=<%= @macaddy %>
 MASTER=<%= @master %>
 SLAVE=yes
 TYPE=Ethernet


### PR DESCRIPTION
Noticed an issue on my forked version with the fix for #37. Described in #34.

The HWADDR was referencing the macaddress variable instead of the macaddy variable