### PR TITLE
Allow for the HWADDR configuration line to optionally disabled

### DIFF
--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -8,6 +8,7 @@
 #   $ipaddress    - required
 #   $netmask      - required
 #   $gateway      - optional
+#   $hwaddr_disable   - optional
 #   $macaddress   - optional - defaults to macaddress_$title
 #   $userctl      - optional - defaults to false
 #   $mtu          - optional
@@ -44,6 +45,7 @@ define network::if::static (
   $ipaddress,
   $netmask,
   $gateway = '',
+  $hwaddr_disable = false,
   $macaddress = '',
   $userctl = false,
   $mtu = '',
@@ -65,18 +67,19 @@ define network::if::static (
   validate_bool($userctl)
 
   network_if_base { $title:
-    ensure       => $ensure,
-    ipaddress    => $ipaddress,
-    netmask      => $netmask,
-    gateway      => $gateway,
-    macaddress   => $macaddy,
-    bootproto    => 'none',
-    userctl      => $userctl,
-    mtu          => $mtu,
-    ethtool_opts => $ethtool_opts,
-    peerdns      => $peerdns,
-    dns1         => $dns1,
-    dns2         => $dns2,
-    domain       => $domain,
+    ensure         => $ensure,
+    ipaddress      => $ipaddress,
+    netmask        => $netmask,
+    gateway        => $gateway,
+    hwaddr_disable => $hwaddr_disable,
+    macaddress     => $macaddy,
+    bootproto      => 'none',
+    userctl        => $userctl,
+    mtu            => $mtu,
+    ethtool_opts   => $ethtool_opts,
+    peerdns        => $peerdns,
+    dns1           => $dns1,
+    dns2           => $dns2,
+    domain         => $domain,
   }
 } # define network::if::static

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,7 @@ class network {
 #   $ensure       - required - up|down
 #   $ipaddress    - required
 #   $netmask      - required
+#   $hwaddr_disable   - optional
 #   $macaddress   - required
 #   $gateway      - optional
 #   $bootproto    - optional
@@ -96,6 +97,7 @@ define network_if_base (
   $ensure,
   $ipaddress,
   $netmask,
+  $hwaddr_disable = false,
   $macaddress,
   $gateway = '',
   $bootproto = 'none',

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -3,7 +3,7 @@
 ###
 DEVICE=<%= @interface %>
 BOOTPROTO=<%= @bootproto %>
-<% if !@macaddress.empty? %>HWADDR=<%= @macaddress %>
+<% if @hwaddr_disable != true and !@macaddress.empty? %>HWADDR=<%= @macaddress %>
 <% end -%>
 ONBOOT=<%= @onboot %>
 HOTPLUG=<%= @onboot %>


### PR DESCRIPTION
Unfortunately in some really unsual environements, the MAC address may not be persistent. In some environments there may even be a valid reason for the MAC address not being persistent.

In our z/vm environment a guest may move from one LPAR to another and boot up with a different MAC address. Hence it's useful to make the HWADDR line in the network config file optional. This doesn't cause an issue, since the SUBCHANNELS line exists in this case.
Ideally our z/vm environment would be configured correctly, in that the MAC address would be persistent but that is another issue altogether.
