### PR TITLE
Add support for z/linux networking params NETTYPE and SUBCHANNELS

### DIFF
--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -12,6 +12,8 @@
 #   $userctl      - optional - defaults to false
 #   $mtu          - optional
 #   $ethtool_opts - optional
+#   $subchannels  - optional
+#   $nettype      - optional
 #   $peerdns      - optional
 #   $dns1         - optional
 #   $dns2         - optional
@@ -48,6 +50,8 @@ define network::if::static (
   $userctl = false,
   $mtu = '',
   $ethtool_opts = '',
+  $subchannels = '',
+  $nettype = '',
   $peerdns = false,
   $dns1 = '',
   $dns2 = '',
@@ -74,6 +78,8 @@ define network::if::static (
     userctl      => $userctl,
     mtu          => $mtu,
     ethtool_opts => $ethtool_opts,
+    subchannels  => $subchannels,
+    nettype      => $nettype,
     peerdns      => $peerdns,
     dns1         => $dns1,
     dns2         => $dns2,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,8 @@ class network {
 #   $userctl      - optional - defaults to false
 #   $mtu          - optional
 #   $ethtool_opts - optional
+#   $subchannels  - optional
+#   $nettype      - optional
 #   $bonding_opts - optional
 #   $isalias      - optional
 #   $peerdns      - optional
@@ -102,6 +104,8 @@ define network_if_base (
   $userctl = false,
   $mtu = '',
   $ethtool_opts = '',
+  $subchannels = '',
+  $nettype = '',
   $bonding_opts = undef,
   $isalias = false,
   $peerdns = false,

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -20,6 +20,10 @@ TYPE=Ethernet
 <% end -%>
 <% if !@ethtool_opts.empty? %>ETHTOOL_OPTS="<%= @ethtool_opts %>"
 <% end -%>
+<% if !@subchannels.empty? %>SUBCHANNELS="<%= @subchannels %>"
+<% end -%>
+<% if !@nettype.empty? %>NETTYPE="<%= @nettype %>"
+<% end -%>
 <% if !@peerdns %>PEERDNS=no
 <% else %>PEERDNS=yes
 <% if !@dns1_real.empty? %>DNS1=<%= @dns1_real %>


### PR DESCRIPTION
This is a quick attempt to address razorsedge/puppet-network#41

It doesn't have the full list of z/linux specific parameters, but perhaps some of the commonly used ones.
