### PR TITLE
allow setting macaddress

### DIFF
--- a/manifests/if/bridge.pp
+++ b/manifests/if/bridge.pp
@@ -8,6 +8,7 @@
 #   $bridge       - required - bridge interface name
 #   $mtu          - optional
 #   $ethtool_opts - optional
+#   $macaddress   - optional
 #
 # === Actions:
 #
@@ -32,7 +33,8 @@ define network::if::bridge (
   $ensure,
   $bridge,
   $mtu = '',
-  $ethtool_opts = ''
+  $ethtool_opts = '',
+  $macaddress =''
 ) {
   # Validate our regular expressions
   $states = [ '^up$', '^down$' ]
@@ -43,7 +45,7 @@ define network::if::bridge (
     ipaddress    => '',
     netmask      => '',
     gateway      => '',
-    macaddress   => '',
+    macaddress   => $macaddress,,
     bootproto    => 'none',
     mtu          => $mtu,
     ethtool_opts => $ethtool_opts,


### PR DESCRIPTION
This is needed to add a physical interface to the bridge with a MAC.
Example:

```
  network::bridge::static { 'br1':
    ensure    => 'up',
    ipaddress => $::ipaddress,
    netmask   => $::netmask,
  }
  network::if::bridge { 'em1':
    macaddress   => $macaddress_em1,
    ensure       => 'up',
    ethtool_opts => '',
    bridge       => 'br1',
  }```