### PR TITLE
Feature: Add class that allows configuration of a bond or bridge interface with no ipaddress

### DIFF
--- a/manifests/bond/null.pp
+++ b/manifests/bond/null.pp
@@ -1,0 +1,103 @@
+# == Definition: network::bond::null
+#
+# Creates a bonded interface with static IP address and enables the bonding
+# driver.
+#
+# === Parameters:
+#
+#   $ensure       - required - up|down
+#   $mtu          - optional
+#   $ethtool_opts - optional
+#   $bonding_opts - optional
+#
+# === Actions:
+#
+# Deploys the file /etc/sysconfig/network-scripts/ifcfg-$name.
+# Updates /etc/modprobe.conf with bonding driver parameters.
+#
+# === Sample Usage:
+#
+#   network::bond::null { 'bond0':
+#     ensure       => 'up',
+#     bonding_opts => 'mode=active-backup miimon=100',
+#   }
+#
+# === Authors:
+#
+# Mike Arnold <mike@razorsedge.org>
+#
+# === Copyright:
+#
+# Copyright (C) 2011 Mike Arnold, unless otherwise noted.
+#
+define network::bond::null (
+  $ensure,
+  $mtu = '',
+  $ethtool_opts = '',
+  $bonding_opts = 'miimon=100',
+  $peerdns = false,
+
+) {
+  # Validate our regular expressions
+  $states = [ '^up$', '^down$' ]
+  validate_re($ensure, $states, '$ensure must be either "up" or "down".')
+  $ipaddress = ''
+  $netmask = ''
+  $gateway = ''
+  $dns1 = ''
+  $dns2 = ''
+  $domain = ''
+  network_if_base { $title:
+    ensure       => $ensure,
+    ipaddress    => $ipaddress,
+    netmask      => $netmask,
+    gateway      => $gateway,
+    macaddress   => '',
+    bootproto    => 'none',
+    mtu          => $mtu,
+    ethtool_opts => $ethtool_opts,
+    bonding_opts => $bonding_opts,
+    peerdns      => $peerdns,
+    dns1         => $dns1,
+    dns2         => $dns2,
+    domain       => $domain,
+  }
+
+  # Only install "alias bondN bonding" on old OSs that support
+  # /etc/modprobe.conf.
+  case $::operatingsystem {
+    /^(RedHat|CentOS|OEL|OracleLinux|SLC|Scientific)$/: {
+      case $::operatingsystemrelease {
+        /^[45]/: {
+          augeas { "modprobe.conf_${title}":
+            context => '/files/etc/modprobe.conf',
+            changes => [
+              "set alias[last()+1] ${title}",
+              'set alias[last()]/modulename bonding',
+            ],
+            onlyif  => "match alias[*][. = '${title}'] size == 0",
+            before  => Network_if_base[$title],
+          }
+        }
+        default: {}
+      }
+    }
+    'Fedora': {
+      case $::operatingsystemrelease {
+        /^(1|2|3|4|5|6|7|8|9|10|11)$/: {
+          augeas { "modprobe.conf_${title}":
+            context => '/files/etc/modprobe.conf',
+            changes => [
+              "set alias[last()+1] ${title}",
+              'set alias[last()]/modulename bonding',
+            ],
+            onlyif  => "match alias[*][. = '${title}'] size == 0",
+            before  => Network_if_base[$title],
+          }
+        }
+        default: {}
+      }
+    }
+    default: {}
+  }
+} # define network::bond::static

--- a/manifests/bridge/null.pp
+++ b/manifests/bridge/null.pp
@@ -1,0 +1,103 @@
+# == Definition: network::bridge::static
+#
+# Creates a bridge interface with static IP address.
+#
+# === Parameters:
+#
+#   $ensure        - required - up|down
+#   $ipaddress     - required
+#   $netmask       - required
+#   $gateway       - optional
+#   $userctl       - optional - defaults to false
+#   $peerdns       - optional
+#   $dns1          - optional
+#   $dns2          - optional
+#   $domain        - optional
+#   $stp           - optional - defaults to false
+#   $delay         - optional - defaults to 30
+#   $bridging_opts - optional
+#
+# === Actions:
+#
+# Deploys the file /etc/sysconfig/network-scripts/ifcfg-$name.
+#
+# === Sample Usage:
+#
+#   network::bridge::static { 'br0':
+#     ensure        => 'up',
+#     ipaddress     => '10.21.30.248',
+#     netmask       => '255.255.255.128',
+#     domain        => 'is.domain.com domain.com',
+#     stp           => true,
+#     delay         => '0',
+#     bridging_opts => 'priority=65535',
+#   }
+#
+# === Authors:
+#
+# David Cote
+# Mike Arnold <mike@razorsedge.org>
+#
+# === Copyright:
+#
+# Copyright (C) 2013 David Cote, unless otherwise noted.
+# Copyright (C) 2013 Mike Arnold, unless otherwise noted.
+#
+define network::bridge::static (
+  $ensure,
+  $ipaddress,
+  $netmask,
+  $gateway = '',
+  $bootproto = 'static',
+  $userctl = false,
+  $peerdns = false,
+  $dns1 = '',
+  $dns2 = '',
+  $domain = '',
+  $stp = false,
+  $delay = '30',
+  $bridging_opts = ''
+) {
+  # Validate our regular expressions
+  $states = [ '^up$', '^down$' ]
+  validate_re($ensure, $states, '$ensure must be either "up" or "down".')
+  # Validate our data
+  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  # Validate booleans
+  validate_bool($userctl)
+  validate_bool($stp)
+
+  include 'network'
+
+  $interface = $name
+
+  # Deal with the case where $dns2 is non-empty and $dns1 is empty.
+  if $dns2 != '' {
+    if $dns1 == '' {
+      $dns1_real = $dns2
+      $dns2_real = ''
+    } else {
+      $dns1_real = $dns1
+      $dns2_real = $dns2
+    }
+  } else {
+    $dns1_real = $dns1
+    $dns2_real = $dns2
+  }
+
+  $onboot = $ensure ? {
+    'up'    => 'yes',
+    'down'  => 'no',
+    default => undef,
+  }
+
+  file { "ifcfg-${interface}":
+    ensure  => 'present',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}",
+    content => template('network/ifcfg-br.erb'),
+    notify  => Service['network'],
+  }
+} # define network::bridge::static

--- a/manifests/bridge/null.pp
+++ b/manifests/bridge/null.pp
@@ -1,18 +1,11 @@
-# == Definition: network::bridge::static
+# == Definition: network::bridge::null
 #
-# Creates a bridge interface with static IP address.
+# Creates a bridge interface with no IP address.
 #
 # === Parameters:
 #
 #   $ensure        - required - up|down
-#   $ipaddress     - required
-#   $netmask       - required
-#   $gateway       - optional
 #   $userctl       - optional - defaults to false
-#   $peerdns       - optional
-#   $dns1          - optional
-#   $dns2          - optional
-#   $domain        - optional
 #   $stp           - optional - defaults to false
 #   $delay         - optional - defaults to 30
 #   $bridging_opts - optional
@@ -23,18 +16,15 @@
 #
 # === Sample Usage:
 #
-#   network::bridge::static { 'br0':
+#   network::bridge::null { 'br0':
 #     ensure        => 'up',
-#     ipaddress     => '10.21.30.248',
-#     netmask       => '255.255.255.128',
-#     domain        => 'is.domain.com domain.com',
 #     stp           => true,
 #     delay         => '0',
 #     bridging_opts => 'priority=65535',
 #   }
 #
 # === Authors:
-#
+# David Gibbons <dgibbons@peakhosting.com>
 # David Cote
 # Mike Arnold <mike@razorsedge.org>
 #
@@ -43,17 +33,10 @@
 # Copyright (C) 2013 David Cote, unless otherwise noted.
 # Copyright (C) 2013 Mike Arnold, unless otherwise noted.
 #
-define network::bridge::static (
+define network::bridge::null (
   $ensure,
-  $ipaddress,
-  $netmask,
-  $gateway = '',
-  $bootproto = 'static',
+  $bootproto = 'none',
   $userctl = false,
-  $peerdns = false,
-  $dns1 = '',
-  $dns2 = '',
-  $domain = '',
   $stp = false,
   $delay = '30',
   $bridging_opts = ''
@@ -61,29 +44,18 @@ define network::bridge::static (
   # Validate our regular expressions
   $states = [ '^up$', '^down$' ]
   validate_re($ensure, $states, '$ensure must be either "up" or "down".')
-  # Validate our data
-  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
   # Validate booleans
   validate_bool($userctl)
   validate_bool($stp)
 
   include 'network'
-
+  $ipaddress = ''
+  $netmask = ''
+  $gateway = ''
+  $dns1_real = ''
+  $dns2_real = ''
+  $domain = ''
   $interface = $name
-
-  # Deal with the case where $dns2 is non-empty and $dns1 is empty.
-  if $dns2 != '' {
-    if $dns1 == '' {
-      $dns1_real = $dns2
-      $dns2_real = ''
-    } else {
-      $dns1_real = $dns1
-      $dns2_real = $dns2
-    }
-  } else {
-    $dns1_real = $dns1
-    $dns2_real = $dns2
-  }
 
   $onboot = $ensure ? {
     'up'    => 'yes',


### PR DESCRIPTION
I didn't want to alter the ip checking behavior of the static classes but I'm needing interfaces with no set addresses for a complex bonding/bridge setup. It would have also been possible to check/set ipaddress to an empty string in the static classes and allow that but the logic you have in place already seems specific in its purpose, it's also calling it specifically a "static" class so I figured a matching "null" class might be the most consistent solution.