### PR TITLE
Allow setting DHCP_HOSTNAME on dynamic interfaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Introduction
 
 This module manages Red Hat/Fedora traditional network configuration.
 
-It allows for static, dhcp, and bootp configuration of normal and bonded interfaces as well as bridges and VLANs.  There is support for aliases on interfaces as well as alias ranges.  It can configure static routes.  It can configure MTU, ETHTOOL_OPTS, and BONDING_OPTS on a per-interface basis.
+It allows for static, dhcp, and bootp configuration of normal and bonded interfaces as well as bridges and VLANs.  There is support for aliases on interfaces as well as alias ranges.  It can configure static routes.  It can configure MTU, DHCP_HOSTNAME, ETHTOOL_OPTS, and BONDING_OPTS on a per-interface basis.
 
 It can configure the following files:
 
@@ -59,10 +59,11 @@ Normal interface - dhcp (minimal):
 Normal interface - dhcp:
 
     network::if::dynamic { 'eth3':
-      ensure       => 'up',
-      macaddress   => 'fe:fe:fe:ae:ae:ae',
-      mtu          => '1500',
-      ethtool_opts => 'autoneg off speed 100 duplex full',
+      ensure        => 'up',
+      macaddress    => 'fe:fe:fe:ae:ae:ae',
+      mtu           => '1500',
+      dhcp_hostname => $::hostname,
+      ethtool_opts  => 'autoneg off speed 100 duplex full',
     }
 
 Normal interface - bootp (minimal):

--- a/manifests/if/dynamic.pp
+++ b/manifests/if/dynamic.pp
@@ -4,12 +4,13 @@
 #
 # === Parameters:
 #
-#   $ensure       - required - up|down
-#   $macaddress   - optional - defaults to macaddress_$title
-#   $bootproto    - optional - defaults to "dhcp"
-#   $userctl      - optional - defaults to false
-#   $mtu          - optional
-#   $ethtool_opts - optional
+#   $ensure        - required - up|down
+#   $macaddress    - optional - defaults to macaddress_$title
+#   $bootproto     - optional - defaults to "dhcp"
+#   $userctl       - optional - defaults to false
+#   $mtu           - optional
+#   $dhcp_hostname - optional
+#   $ethtool_opts  - optional
 #
 # === Actions:
 #
@@ -42,6 +43,7 @@ define network::if::dynamic (
   $bootproto = 'dhcp',
   $userctl = false,
   $mtu = '',
+  $dhcp_hostname = '',
   $ethtool_opts = '',
   $linkdelay = ''
 ) {
@@ -60,15 +62,16 @@ define network::if::dynamic (
   validate_bool($userctl)
 
   network_if_base { $title:
-    ensure       => $ensure,
-    ipaddress    => '',
-    netmask      => '',
-    gateway      => '',
-    macaddress   => $macaddy,
-    bootproto    => $bootproto,
-    userctl      => $userctl,
-    mtu          => $mtu,
-    ethtool_opts => $ethtool_opts,
-    linkdelay    => $linkdelay,
+    ensure        => $ensure,
+    ipaddress     => '',
+    netmask       => '',
+    gateway       => '',
+    macaddress    => $macaddy,
+    bootproto     => $bootproto,
+    userctl       => $userctl,
+    mtu           => $mtu,
+    dhcp_hostname => $dhcp_hostname,
+    ethtool_opts  => $ethtool_opts,
+    linkdelay     => $linkdelay,
   }
 } # define network::if::dynamic

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,22 +49,23 @@ class network {
 #
 # === Parameters:
 #
-#   $ensure       - required - up|down
-#   $ipaddress    - required
-#   $netmask      - required
-#   $macaddress   - required
-#   $gateway      - optional
-#   $bootproto    - optional
-#   $userctl      - optional - defaults to false
-#   $mtu          - optional
-#   $ethtool_opts - optional
-#   $bonding_opts - optional
-#   $isalias      - optional
-#   $peerdns      - optional
-#   $dns1         - optional
-#   $dns2         - optional
-#   $domain       - optional
-#   $bridge       - optional
+#   $ensure        - required - up|down
+#   $ipaddress     - required
+#   $netmask       - required
+#   $macaddress    - required
+#   $gateway       - optional
+#   $bootproto     - optional
+#   $userctl       - optional - defaults to false
+#   $mtu           - optional
+#   $dhcp_hostname - optional
+#   $ethtool_opts  - optional
+#   $bonding_opts  - optional
+#   $isalias       - optional
+#   $peerdns       - optional
+#   $dns1          - optional
+#   $dns2          - optional
+#   $domain        - optional
+#   $bridge        - optional
 #
 # === Actions:
 #
@@ -100,6 +101,7 @@ define network_if_base (
   $bootproto = 'none',
   $userctl = false,
   $mtu = '',
+  $dhcp_hostname = '',
   $ethtool_opts = '',
   $bonding_opts = undef,
   $isalias = false,

--- a/spec/defines/network_if_dynamic_spec.rb
+++ b/spec/defines/network_if_dynamic_spec.rb
@@ -51,13 +51,14 @@ describe 'network::if::dynamic', :type => 'define' do
   context 'optional parameters' do
     let(:title) { 'eth99' }
     let :params do {
-      :ensure       => 'down',
-      :macaddress   => 'ef:ef:ef:ef:ef:ef',
-      :bootproto    => 'bootp',
-      :userctl      => true,
-      :mtu          => '1500',
-      :ethtool_opts => 'speed 100 duplex full autoneg off',
-      :linkdelay    => '5',
+      :ensure        => 'down',
+      :macaddress    => 'ef:ef:ef:ef:ef:ef',
+      :bootproto     => 'bootp',
+      :userctl       => true,
+      :mtu           => '1500',
+      :ethtool_opts  => 'speed 100 duplex full autoneg off',
+      :dhcp_hostname => 'hostname',
+      :linkdelay     => '5',
     }
     end
     let :facts do {
@@ -82,6 +83,7 @@ describe 'network::if::dynamic', :type => 'define' do
         'HOTPLUG=no',
         'TYPE=Ethernet',
         'MTU=1500',
+        'DHCP_HOSTNAME="hostname"',
         'ETHTOOL_OPTS="speed 100 duplex full autoneg off"',
         'USERCTL=yes',
         'LINKDELAY=5',

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -18,6 +18,8 @@ TYPE=Ethernet
 <% end -%>
 <% if @bonding_opts %>BONDING_OPTS="<%= @bonding_opts %>"
 <% end -%>
+<% if @dhcp_hostname %>DHCP_HOSTNAME="<%= @dhcp_hostname %>"
+<% end -%>
 <% if !@ethtool_opts.empty? %>ETHTOOL_OPTS="<%= @ethtool_opts %>"
 <% end -%>
 <% if !@peerdns %>PEERDNS=no


### PR DESCRIPTION
This patch allows setting the DHCP_HOSTNAME variable within an interface configuration file. When bringing up an interface with DHCP, the value of this variable will be used as the client's hostname when requesting a DHCP lease. It also targets the correct upstream branch. :+1: 