### PR TITLE
allow the optional field ipv6defaultdev to set IPV6_DEFAULTDEV in the global network settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Global network setting (IPv6 enabled):
       ipv6networking => true,
     }
 
+Global network setting with IPv6 enabled with optional default device for IPv6 traffic:
+
+    class { 'network::global':
+      ipv6gateway    => '123:4567:89ab:cdef:123:4567:89ab:1',
+      ipv6networking => true,
+      ipv6defaultdev => 'eth1',
+    }
+
+
 Normal interface - static (minimal):
 
     network::if::static { 'eth0':

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -17,6 +17,8 @@
 #                                Overrides $gateway in network::global.  Must have
 #                                $gateway defined in network::if or network::bond.
 #   $ipv6gateway    - optional - Sets the default gateway for the IPv6 address - IPv6 must be enabled
+#   $ipv6defaultdev - optional - Determines the device to use as the default gateway
+#                                for IPV6 traffic.
 #   $nisdomain      - optional - Configures the NIS domainname.
 #   $vlan           - optional - yes|no to enable VLAN kernel module
 #   $ipv6networking - optional - enables / disables IPv6 globally
@@ -37,6 +39,7 @@
 #     gateway        => '1.2.3.1',
 #     gatewaydev     => 'eth0',
 #     ipv6gateway    => '123:4567:89ab:cdef:123:4567:89ab:1',
+#     ipv6defaultdev => 'eth0',
 #     nisdomain      => 'domain.tld',
 #     vlan           => 'yes',
 #     ipv6networking => true,
@@ -60,6 +63,7 @@ class network::global (
   $gateway        = '',
   $gatewaydev     = '',
   $ipv6gateway    = '',
+  $ipv6defaultdev = '',
   $nisdomain      = '',
   $vlan           = '',
   $ipv6networking = false,

--- a/spec/classes/network_global_spec.rb
+++ b/spec/classes/network_global_spec.rb
@@ -125,6 +125,7 @@ describe 'network::global', :type => 'class' do
       :nozeroconf     => 'yes',
       :ipv6networking => true,
       :ipv6gateway    => '123:4567:89ab:cdef:123:4567:89ab:1',
+      :ipv6defaultdev => 'eth3',
     }
     end
     let :facts do {
@@ -137,6 +138,7 @@ describe 'network::global', :type => 'class' do
         'NETWORKING=yes',
         'NETWORKING_IPV6=yes',
         'IPV6_DEFAULTGW=123:4567:89ab:cdef:123:4567:89ab:1',
+        'IPV6_DEFAULTDEV=eth3',
         'HOSTNAME=myHostname',
         'GATEWAY=1.2.3.4',
         'GATEWAYDEV=eth2',

--- a/templates/network.erb
+++ b/templates/network.erb
@@ -6,6 +6,8 @@ NETWORKING=yes
 <% else %>NETWORKING_IPV6=yes
 <% if !@ipv6gateway.empty? %>IPV6_DEFAULTGW=<%= @ipv6gateway %>
 <% end -%>
+<% if !@ipv6defaultdev.empty? %>IPV6_DEFAULTDEV=<%= @ipv6defaultdev %>
+<% end -%>
 <% end -%>
 <% if !@hostname.empty? %>HOSTNAME=<%= @hostname %>
 <% else %>HOSTNAME=<%= scope.lookupvar('::fqdn') %>

--- a/tests/global.pp
+++ b/tests/global.pp
@@ -5,4 +5,5 @@ class { 'network::global':
   nozeroconf     => 'yes',
   ipv6networking => true,
   ipv6gateway    => '123:4567:89ab:cdef:123:4567:89ab:1',
+  ipv6defaultdev => 'eth1',
 }


### PR DESCRIPTION
This adds the field ipv6defaultdev so you can set IPV6_DEFAULTDEV.

Tested on my server at Hetzner where you need this option, see for example http://wiki.hetzner.de/index.php/Netzkonfiguration_CentOS/en