### PR TITLE
Create new manifest network::bond for creating bond interface with no IP

### DIFF
--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -1,0 +1,92 @@
+# == Definition: network::bond
+#
+# Creates a bonded interface with no IP information
+#
+# === Parameters:
+#
+#   $ensure       - required - up|down
+#   $mtu          - optional
+#   $ethtool_opts - optional
+#   $bonding_opts - optional
+#
+# === Actions:
+#
+# Deploys the file /etc/sysconfig/network-scripts/ifcfg-$name.
+# Updates /etc/modprobe.conf with bonding driver parameters.
+#
+# === Sample Usage:
+#
+#   network::bond { 'bond2':
+#     ensure => 'up',
+#   }
+#
+# === Authors:
+#
+# Mike Arnold <mike@razorsedge.org>
+#
+# === Copyright:
+#
+# Copyright (C) 2011 Mike Arnold, unless otherwise noted.
+#
+define network::bond (
+  $ensure,
+  $mtu = '',
+  $ethtool_opts = '',
+  $bonding_opts = 'miimon=100'
+) {
+  # Validate our regular expressions
+  $states = [ '^up$', '^down$' ]
+  validate_re($ensure, $states, '$ensure must be either "up" or "down".')
+
+  network_if_base { $title:
+    ensure       => $ensure,
+    ipaddress    => '',
+    netmask      => '',
+    gateway      => '',
+    macaddress   => '',
+    bootproto    => 'none',
+    ipv6address  => '',
+    ipv6gateway  => '',
+    mtu          => $mtu,
+    ethtool_opts => $ethtool_opts,
+    bonding_opts => $bonding_opts,
+  }
+
+  # Only install "alias bondN bonding" on old OSs that support
+  # /etc/modprobe.conf.
+  case $::operatingsystem {
+    /^(RedHat|CentOS|OEL|OracleLinux|SLC|Scientific)$/: {
+      case $::operatingsystemrelease {
+        /^[45]/: {
+          augeas { "modprobe.conf_${title}":
+            context => '/files/etc/modprobe.conf',
+            changes => [
+              "set alias[last()+1] ${title}",
+              'set alias[last()]/modulename bonding',
+            ],
+            onlyif  => "match alias[*][. = '${title}'] size == 0",
+            before  => Network_if_base[$title],
+          }
+        }
+        default: {}
+      }
+    }
+    'Fedora': {
+      case $::operatingsystemrelease {
+        /^(1|2|3|4|5|6|7|8|9|10|11)$/: {
+          augeas { "modprobe.conf_${title}":
+            context => '/files/etc/modprobe.conf',
+            changes => [
+              "set alias[last()+1] ${title}",
+              'set alias[last()]/modulename bonding',
+            ],
+            onlyif  => "match alias[*][. = '${title}'] size == 0",
+            before  => Network_if_base[$title],
+          }
+        }
+        default: {}
+      }
+    }
+    default: {}
+  }
+} # define network::bond::dynamic


### PR DESCRIPTION
This will create a new manifest that follows the pattern of network::bridge to create a bond interface with no IP. This is useful when using bond interfaces along with VLANS and no default VLAN.