### PR TITLE
Modify ifcfg-eth template so it applies DNS servers correctly

### DIFF
--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -24,12 +24,12 @@ TYPE=Ethernet
 <% end -%>
 <% if !@peerdns %>PEERDNS=no
 <% else %>PEERDNS=yes
+<% end -%>
 <% if !@dns1_real.empty? %>DNS1=<%= @dns1_real %>
 <% end -%>
 <% if !@dns2_real.empty? %>DNS2=<%= @dns2_real %>
 <% end -%>
 <% if !@domain.empty? %>DOMAIN="<%= @domain %>"
-<% end -%>
 <% end -%>
 <% if @userctl %>USERCTL=yes
 <% end -%>


### PR DESCRIPTION
I was using this module with some systems and noticed whatever I did the DNS servers weren't being applied into /etc/sysconfig/network-scripts/ifcfg-ethX. 

It appears there was an error in the logic of the template which meant that if PEERDNS was off no DNS configuration would be populated. 

I've modified the logic and it looks right (and works) for me now.
