### PR TITLE
support for multiple static ipv6 addresses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,5 @@ matrix:
   - rvm: 2.1.0
     env: PUPPET_GEM_VERSION="~> 4.0"
 notifications:
-  email: false
+  email:
+    - github@razorsedge.org

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -72,9 +72,9 @@ define network::if::static (
   if is_array($ipv6address) {
     if size($ipv6address) > 0 {
       validate_ip_address { $ipv6address: }
+      $primary_ipv6address = $ipv6address[0]
+      $secondary_ipv6addresses = delete_at($ipv6address, 0)
     }
-    $primary_ipv6address = $ipv6address[0]
-    $secondary_ipv6addresses = delete_at($ipv6address, 0)
   } elsif $ipv6address {
     if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IP(v6) address.") }
     $primary_ipv6address = $ipv6address

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -76,7 +76,7 @@ define network::if::static (
       $secondary_ipv6addresses = delete_at($ipv6address, 0)
     }
   } elsif $ipv6address {
-    if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IP(v6) address.") }
+    if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
     $primary_ipv6address = $ipv6address
     $secondary_ipv6addresses = undef
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,7 @@ define network_if_base (
   $ipv6gateway = undef,
   $ipv6init = false,
   $ipv6autoconf = false,
+  $ipv6secondaries = undef,
   $bootproto = 'none',
   $userctl = false,
   $mtu = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,3 +173,24 @@ define network_if_base (
     notify  => Service['network'],
   }
 } # define network_if_base
+
+# == Definition: validate_ip_address
+#
+# This definition can be used to call is_ip_address on an array of ip addresses.
+#
+# === Parameters:
+#
+# None
+#
+# === Actions:
+#
+# Runs is_ip_address on the name of the define and fails if it is not a valid IP address.
+#
+# === Sample Usage:
+#
+# $ips = [ '10.21.30.248', '123:4567:89ab:cdef:123:4567:89ab:cdef' ]
+# validate_ip_address { $ips: }
+#
+define validate_ip_address {
+  if ! is_ip_address($name) { fail("${name} is not an IP(v6) address.") }
+} # define validate_ip_address

--- a/spec/defines/network_if_static_spec.rb
+++ b/spec/defines/network_if_static_spec.rb
@@ -41,7 +41,9 @@ describe 'network::if::static', :type => 'define' do
     }
     end
     it 'should fail' do
-      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /\{"notAn"=>"IP"\} is not an IPv6 address\./)
+      # there are major differences in the way that different ruby versions translate a hash into a string
+      # which makes it hard to match the whole string
+      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /.*notAn.*IP.* is not an IPv6 address\./)
     end
   end
 

--- a/spec/defines/network_if_static_spec.rb
+++ b/spec/defines/network_if_static_spec.rb
@@ -13,24 +13,55 @@ describe 'network::if::static', :type => 'define' do
     }
     end
     it 'should fail' do
-      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /notAnIP is not an IP address./)
+      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /notAnIP is not an IP address\./)
     end
   end
 
   context 'incorrect value: ipv6address' do
     let(:title) { 'eth77' }
     let :params do {
-      :ensure    => 'up',
-      :ipaddress => '1.2.3.4',
-      :netmask   => '255.255.255.0',
+      :ensure      => 'up',
+      :ipaddress   => '1.2.3.4',
+      :netmask     => '255.255.255.0',
       :ipv6address => 'notAnIP',
     }
     end
     it 'should fail' do
-      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /notAnIP is not an IPv6 address./)
+      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /notAnIP is not an IPv6 address\./)
     end
   end
 
+  context 'incorrect hash value: ipv6address' do
+    let(:title) { 'eth77' }
+    let :params do {
+      :ensure      => 'up',
+      :ipaddress   => '1.2.3.4',
+      :netmask     => '255.255.255.0',
+      :ipv6address => { 'notAn' => 'IP' },
+    }
+    end
+    it 'should fail' do
+      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /{"notAn"=>"IP"} is not an IPv6 address\./)
+    end
+  end
+
+  context 'incorrect value: ipv6address in array' do
+    let(:title) { 'eth77' }
+    let :params do {
+      :ensure      => 'up',
+      :ipaddress   => '1.2.3.4',
+      :netmask     => '255.255.255.0',
+      :ipv6address => [
+        '123:4567:89ab:cdef:123:4567:89ab:cdee',
+        'notAnIP',
+        '123:4567:89ab:cdef:123:4567:89ab:cdef',
+      ]
+    }
+    end
+    it 'should fail' do
+      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /notAnIP is not an IP\(v6\) address\./)
+    end
+  end
 
   context 'required parameters' do
     let(:title) { 'eth1' }
@@ -173,4 +204,94 @@ describe 'network::if::static', :type => 'define' do
     it { should contain_service('network') }
   end
 
+  context 'optional parameters - single ipv6address in array' do
+    let(:title) { 'eth1' }
+    let :params do {
+      :ensure      => 'up',
+      :ipaddress   => '1.2.3.4',
+      :netmask     => '255.255.255.0',
+      :ipv6init    => true,
+      :ipv6address => [
+        '123:4567:89ab:cdef:123:4567:89ab:cdee',
+      ],
+    }
+    end
+    let :facts do {
+      :osfamily        => 'RedHat',
+      :macaddress_eth1 => 'fe:fe:fe:aa:aa:aa',
+    }
+    end
+    it { should contain_file('ifcfg-eth1').with(
+      :ensure => 'present',
+      :mode   => '0644',
+      :owner  => 'root',
+      :group  => 'root',
+      :path   => '/etc/sysconfig/network-scripts/ifcfg-eth1',
+      :notify => 'Service[network]'
+    )}
+    it 'should contain File[ifcfg-eth1] with required contents' do
+      verify_contents(catalogue, 'ifcfg-eth1', [
+        'DEVICE=eth1',
+        'BOOTPROTO=none',
+        'HWADDR=fe:fe:fe:aa:aa:aa',
+        'ONBOOT=yes',
+        'HOTPLUG=yes',
+        'TYPE=Ethernet',
+        'IPADDR=1.2.3.4',
+        'NETMASK=255.255.255.0',
+        'PEERDNS=no',
+        'IPV6INIT=yes',
+        'IPV6ADDR=123:4567:89ab:cdef:123:4567:89ab:cdee',
+        'NM_CONTROLLED=no',
+      ])
+    end
+    it { should contain_service('network') }
+  end
+
+  context 'optional parameters - multiple ipv6addresses' do
+    let(:title) { 'eth1' }
+    let :params do {
+      :ensure      => 'up',
+      :ipaddress   => '1.2.3.4',
+      :netmask     => '255.255.255.0',
+      :ipv6init    => true,
+      :ipv6address => [
+        '123:4567:89ab:cdef:123:4567:89ab:cded',
+        '123:4567:89ab:cdef:123:4567:89ab:cdee',
+        '123:4567:89ab:cdef:123:4567:89ab:cdef',
+      ],
+    }
+    end
+    let :facts do {
+      :osfamily        => 'RedHat',
+      :macaddress_eth1 => 'fe:fe:fe:aa:aa:aa',
+    }
+    end
+    it { should contain_file('ifcfg-eth1').with(
+      :ensure => 'present',
+      :mode   => '0644',
+      :owner  => 'root',
+      :group  => 'root',
+      :path   => '/etc/sysconfig/network-scripts/ifcfg-eth1',
+      :notify => 'Service[network]'
+    )}
+    it 'should contain File[ifcfg-eth1] with required contents' do
+      verify_contents(catalogue, 'ifcfg-eth1', [
+        'DEVICE=eth1',
+        'BOOTPROTO=none',
+        'HWADDR=fe:fe:fe:aa:aa:aa',
+        'ONBOOT=yes',
+        'HOTPLUG=yes',
+        'TYPE=Ethernet',
+        'IPADDR=1.2.3.4',
+        'NETMASK=255.255.255.0',
+        'PEERDNS=no',
+        'IPV6INIT=yes',
+        'IPV6ADDR=123:4567:89ab:cdef:123:4567:89ab:cded',
+        'IPV6ADDR_SECONDARIES="123:4567:89ab:cdef:123:4567:89ab:cdee 123:4567:89ab:cdef:123:4567:89ab:cdef"',
+        'NM_CONTROLLED=no',
+      ])
+    end
+    it { should contain_service('network') }
+  end
 end

--- a/spec/defines/network_if_static_spec.rb
+++ b/spec/defines/network_if_static_spec.rb
@@ -41,7 +41,7 @@ describe 'network::if::static', :type => 'define' do
     }
     end
     it 'should fail' do
-      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /{"notAn"=>"IP"} is not an IPv6 address\./)
+      expect {should contain_file('ifcfg-eth77')}.to raise_error(Puppet::Error, /\{"notAn"=>"IP"\} is not an IPv6 address\./)
     end
   end
 

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -45,6 +45,8 @@ IPV6INIT=yes
 <% if !@ipv6peerdns %>IPV6_PEERDNS=no
 <% else %>IPV6_PEERDNS=yes
 <% end -%>
+<% if @ipv6secondaries %>IPV6ADDR_SECONDARIES="<%= @ipv6secondaries.join(' ') %>"
+<% end -%>
 <% end -%>
 <% if @bridge %>BRIDGE=<%= @bridge %>
 <% end -%>

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -45,7 +45,7 @@ IPV6INIT=yes
 <% if !@ipv6peerdns %>IPV6_PEERDNS=no
 <% else %>IPV6_PEERDNS=yes
 <% end -%>
-<% if @ipv6secondaries %>IPV6ADDR_SECONDARIES="<%= @ipv6secondaries.join(' ') %>"
+<% if @ipv6secondaries and @ipv6secondaries.length > 0 %>IPV6ADDR_SECONDARIES="<%= @ipv6secondaries.join(' ') %>"
 <% end -%>
 <% end -%>
 <% if @bridge %>BRIDGE=<%= @bridge %>


### PR DESCRIPTION
Added ipv6secondaries parameter (array) to network_if_base which sets IPV6ADDR_SECONDARIES in the ethernet configuration file.
Updated if::static to allow an array of IPv6 addresses to be specified. The first is being used as primary address, the others as secondary addresses.