### PR TITLE
Added support for flush parameter of network::if::static

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,19 @@ Normal interface - VLAN - static (minimal):
       netmask   => '255.255.255.0',
     }
 
+Flush IP addresses:
+
+Network scripts on RHEL7 do not flush IP addresses, so you eventually end up
+with multiple of them, passing `$flush => true` will run `ip addr flush` on
+given interface before notifying network service.
+
+    network::if::static { 'eth0':
+      ensure    => 'up',
+      ipaddress => '1.2.3.4',
+      netmask   => '255.255.255.0',
+      flush     => true
+    }
+
 Notes
 -----
 

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -21,6 +21,7 @@
 #   $dns1         - optional
 #   $dns2         - optional
 #   $domain       - optional
+#   $flush        - optional
 #
 # === Actions:
 #
@@ -65,7 +66,8 @@ define network::if::static (
   $dns1 = undef,
   $dns2 = undef,
   $domain = undef,
-  $linkdelay = undef
+  $linkdelay = undef,
+  $flush = false
 ) {
   # Validate our data
   if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
@@ -86,6 +88,7 @@ define network::if::static (
   validate_bool($ipv6autoconf)
   validate_bool($peerdns)
   validate_bool($ipv6peerdns)
+  validate_bool($flush)
 
   network_if_base { $title:
     ensure       => $ensure,
@@ -107,5 +110,6 @@ define network::if::static (
     dns2         => $dns2,
     domain       => $domain,
     linkdelay    => $linkdelay,
+    flush        => $flush
   }
 } # define network::if::static

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -168,10 +168,11 @@ define network_if_base (
   if $flush {
     exec { 'network-flush':
       user        => 'root',
-      command     => "/usr/sbin/ip addr flush dev ${interface}",
+      command     => "ip addr flush dev ${interface}",
       refreshonly => true,
       subscribe   => File["ifcfg-${interface}"],
-      before      => Service['network']
+      before      => Service['network'],
+      path        => '/sbin:/usr/sbin'
     }
   }
 

--- a/spec/defines/network_if_static_spec.rb
+++ b/spec/defines/network_if_static_spec.rb
@@ -173,4 +173,22 @@ describe 'network::if::static', :type => 'define' do
     it { should contain_service('network') }
   end
 
+  context 'flush => true - ip addr flush' do
+    let(:title) { 'eth1' }
+    let :params do {
+      :ensure    => 'up',
+      :ipaddress => '1.2.3.4',
+      :netmask   => '255.255.255.0',
+      :flush     => true
+    }
+    end
+    let :facts do {
+      :osfamily        => 'RedHat',
+      :macaddress_eth1 => 'fe:fe:fe:aa:aa:aa',
+    }
+    end
+    it { should contain_exec('network-flush').with_command('/usr/sbin/ip addr flush dev eth1').that_comes_before('Service[network]') }
+  end
+
+
 end

--- a/spec/defines/network_if_static_spec.rb
+++ b/spec/defines/network_if_static_spec.rb
@@ -187,7 +187,7 @@ describe 'network::if::static', :type => 'define' do
       :macaddress_eth1 => 'fe:fe:fe:aa:aa:aa',
     }
     end
-    it { should contain_exec('network-flush').with_command('/usr/sbin/ip addr flush dev eth1').that_comes_before('Service[network]') }
+    it { should contain_exec('network-flush').with_command('ip addr flush dev eth1').that_comes_before('Service[network]') }
   end
 
 


### PR DESCRIPTION
This adds optional parameter flush for network::if::static.

Network scripts on RHEL7 do not flush IP addresses, so you eventually end up with multiple IPs per interface, even though you define just one in your puppet config, passing $flush => true will run `ip addr flush` on given interface before notifying network service.