### PR TITLE
Fix provider centos7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ class network {
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
+    provider   => 'redhat'
   }
 } # class network
 


### PR DESCRIPTION
On CentOS (RHEL) 7  `network` is not native systemd service, but Puppet will use systemd provider by default. This will cause the change on service being applied every run, even though not required.

```
Notice: /Stage[main]/Network/Service[network]/enable: enable changed 'false' to 'true'
```

Changing provider to redhat (chkconfig) makes it behave correctly.