### PR TITLE
Allow HWADDR to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Normal interface - static (minimal):
       netmask   => '255.255.255.128',
     }
 
+Normal interface - static (minimal without HWADDR in ifcfg-file):
+
+    network::if::static { 'eth0':
+      ensure        => 'up',
+      ipaddress     => '1.2.3.248',
+      netmask       => '255.255.255.128',
+      manage_hwaddr => false,
+    }
+
 Normal interface - static:
 
     network::if::static { 'eth1':
@@ -73,6 +82,13 @@ Normal interface - dhcp (minimal):
 
     network::if::dynamic { 'eth2':
       ensure => 'up',
+    }
+
+Normal interface - dhcp (minimal without HWADDR in ifcfg-file):
+
+    network::if::dynamic { 'eth2':
+      ensure        => 'up',
+      manage_hwaddr => false,
     }
 
 Normal interface - dhcp:

--- a/manifests/if/dynamic.pp
+++ b/manifests/if/dynamic.pp
@@ -6,6 +6,7 @@
 #
 #   $ensure          - required - up|down
 #   $macaddress      - optional - defaults to macaddress_$title
+#   $manage_hwaddr   - optional - defaults to true
 #   $bootproto       - optional - defaults to "dhcp"
 #   $userctl         - optional - defaults to false
 #   $mtu             - optional
@@ -43,6 +44,7 @@
 define network::if::dynamic (
   $ensure,
   $macaddress      = undef,
+  $manage_hwaddr   = true,
   $bootproto       = 'dhcp',
   $userctl         = false,
   $mtu             = undef,
@@ -66,6 +68,7 @@ define network::if::dynamic (
   # Validate booleans
   validate_bool($userctl)
   validate_bool($peerdns)
+  validate_bool($manage_hwaddr)
 
   network_if_base { $title:
     ensure          => $ensure,
@@ -73,6 +76,7 @@ define network::if::dynamic (
     netmask         => '',
     gateway         => '',
     macaddress      => $macaddy,
+    manage_hwaddr   => $manage_hwaddr,
     bootproto       => $bootproto,
     userctl         => $userctl,
     mtu             => $mtu,

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -4,24 +4,25 @@
 #
 # === Parameters:
 #
-#   $ensure       - required - up|down
-#   $ipaddress    - required
-#   $netmask      - required
-#   $gateway      - optional
-#   $ipv6address  - optional
-#   $ipv6init     - optional - defaults to false
-#   $ipv6gateway  - optional
-#   $macaddress   - optional - defaults to macaddress_$title
-#   $ipv6autoconf - optional - defaults to false
-#   $userctl      - optional - defaults to false
-#   $mtu          - optional
-#   $ethtool_opts - optional
-#   $peerdns      - optional
-#   $ipv6peerdns  - optional - defaults to false
-#   $dns1         - optional
-#   $dns2         - optional
-#   $domain       - optional
-#   $scope        - optional
+#   $ensure         - required - up|down
+#   $ipaddress      - required
+#   $netmask        - required
+#   $gateway        - optional
+#   $ipv6address    - optional
+#   $ipv6init       - optional - defaults to false
+#   $ipv6gateway    - optional
+#   $manage_hwaddr  - optional - defaults to true
+#   $macaddress     - optional - defaults to macaddress_$title
+#   $ipv6autoconf   - optional - defaults to false
+#   $userctl        - optional - defaults to false
+#   $mtu            - optional
+#   $ethtool_opts   - optional
+#   $peerdns        - optional
+#   $ipv6peerdns    - optional - defaults to false
+#   $dns1           - optional
+#   $dns2           - optional
+#   $domain         - optional
+#   $scope          - optional
 #
 # === Actions:
 #
@@ -57,6 +58,7 @@ define network::if::static (
   $ipv6init = false,
   $ipv6gateway = undef,
   $macaddress = undef,
+  $manage_hwaddr = true,
   $ipv6autoconf = false,
   $userctl = false,
   $mtu = undef,
@@ -88,27 +90,29 @@ define network::if::static (
   validate_bool($ipv6autoconf)
   validate_bool($peerdns)
   validate_bool($ipv6peerdns)
+  validate_bool($manage_hwaddr)
 
   network_if_base { $title:
-    ensure       => $ensure,
-    ipv6init     => $ipv6init,
-    ipaddress    => $ipaddress,
-    ipv6address  => $ipv6address,
-    netmask      => $netmask,
-    gateway      => $gateway,
-    ipv6gateway  => $ipv6gateway,
-    ipv6autoconf => $ipv6autoconf,
-    macaddress   => $macaddy,
-    bootproto    => 'none',
-    userctl      => $userctl,
-    mtu          => $mtu,
-    ethtool_opts => $ethtool_opts,
-    peerdns      => $peerdns,
-    ipv6peerdns  => $ipv6peerdns,
-    dns1         => $dns1,
-    dns2         => $dns2,
-    domain       => $domain,
-    linkdelay    => $linkdelay,
-    scope        => $scope,
+    ensure        => $ensure,
+    ipv6init      => $ipv6init,
+    ipaddress     => $ipaddress,
+    ipv6address   => $ipv6address,
+    netmask       => $netmask,
+    gateway       => $gateway,
+    ipv6gateway   => $ipv6gateway,
+    ipv6autoconf  => $ipv6autoconf,
+    macaddress    => $macaddy,
+    manage_hwaddr => $manage_hwaddr,
+    bootproto     => 'none',
+    userctl       => $userctl,
+    mtu           => $mtu,
+    ethtool_opts  => $ethtool_opts,
+    peerdns       => $peerdns,
+    ipv6peerdns   => $ipv6peerdns,
+    dns1          => $dns1,
+    dns2          => $dns2,
+    domain        => $domain,
+    linkdelay     => $linkdelay,
+    scope         => $scope,
   }
 } # define network::if::static

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,7 @@ class network {
 #   $ipaddress       - required
 #   $netmask         - required
 #   $macaddress      - required
+#   $manage_hwaddr   - optional - defaults to true
 #   $gateway         - optional
 #   $bootproto       - optional
 #   $userctl         - optional - defaults to false
@@ -99,6 +100,7 @@ define network_if_base (
   $ipaddress,
   $netmask,
   $macaddress,
+  $manage_hwaddr   = true,
   $gateway         = undef,
   $ipv6address     = undef,
   $ipv6gateway     = undef,
@@ -130,6 +132,7 @@ define network_if_base (
   validate_bool($ipv6autoconf)
   validate_bool($ipv6peerdns)
   validate_bool($check_link_down)
+  validate_bool($manage_hwaddr)
   # Validate our regular expressions
   $states = [ '^up$', '^down$' ]
   validate_re($ensure, $states, '$ensure must be either "up" or "down".')

--- a/spec/classes/network_global_spec.rb
+++ b/spec/classes/network_global_spec.rb
@@ -113,6 +113,16 @@ describe 'network::global', :type => 'class' do
       end
     end
 
+    context 'manage_hwaddr = foo' do
+      let(:params) {{ :manage_hwaddr  => 'foo' }}
+
+      it 'should fail' do
+        expect {
+          should raise_error(Puppet::Error, /$manage_hwaddr is not a boolean.  It looks to be a String./)
+        }
+      end
+    end
+
   end
 
   context 'on a supported operatingsystem, custom parameters' do

--- a/spec/defines/network_if_dynamic_spec.rb
+++ b/spec/defines/network_if_dynamic_spec.rb
@@ -125,4 +125,38 @@ describe 'network::if::dynamic', :type => 'define' do
     it { should contain_service('network') }
   end
 
+  context 'optional parameters - manage_hwaddr' do
+    let(:title) { 'eth0' }
+    let :params do {
+      :ensure         => 'up',
+      :manage_hwaddr  => false,
+    }
+    end
+    let :facts do {
+      :osfamily         => 'RedHat',
+      :macaddress_eth0 => 'bb:cc:bb:cc:bb:cc',
+    }
+    end
+    it { should contain_file('ifcfg-eth0').with(
+      :ensure => 'present',
+      :mode   => '0644',
+      :owner  => 'root',
+      :group  => 'root',
+      :path   => '/etc/sysconfig/network-scripts/ifcfg-eth0',
+      :notify => 'Service[network]'
+    )}
+    it 'should contain File[ifcfg-eth0] with required contents' do
+      verify_contents(catalogue, 'ifcfg-eth0', [
+        'DEVICE=eth0',
+        'BOOTPROTO=dhcp',
+        'ONBOOT=yes',
+        'HOTPLUG=yes',
+        'TYPE=Ethernet',
+        'NM_CONTROLLED=no',
+      ])
+    end
+    it { should contain_service('network') }
+  end
+
+
 end

--- a/spec/defines/network_if_static_spec.rb
+++ b/spec/defines/network_if_static_spec.rb
@@ -175,4 +175,41 @@ describe 'network::if::static', :type => 'define' do
     it { should contain_service('network') }
   end
 
+  context 'optional parameters - manage_hwaddr' do
+    let(:title) { 'eth0' }
+    let :params do {
+      :ensure         => 'up',
+      :ipaddress      => '1.2.3.4',
+      :netmask        => '255.255.255.0',
+      :manage_hwaddr  => false,
+    }
+    end
+    let :facts do {
+      :osfamily         => 'RedHat',
+      :macaddress_eth0 => 'bb:cc:bb:cc:bb:cc',
+    }
+    end
+    it { should contain_file('ifcfg-eth0').with(
+      :ensure => 'present',
+      :mode   => '0644',
+      :owner  => 'root',
+      :group  => 'root',
+      :path   => '/etc/sysconfig/network-scripts/ifcfg-eth0',
+      :notify => 'Service[network]'
+    )}
+    it 'should contain File[ifcfg-eth0] with required contents' do
+      verify_contents(catalogue, 'ifcfg-eth0', [
+        'DEVICE=eth0',
+        'BOOTPROTO=none',
+        'ONBOOT=yes',
+        'HOTPLUG=yes',
+        'TYPE=Ethernet',
+        'IPADDR=1.2.3.4',
+        'NETMASK=255.255.255.0',
+        'NM_CONTROLLED=no',
+      ])
+    end
+    it { should contain_service('network') }
+  end
+
 end

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -3,7 +3,8 @@
 ###
 DEVICE=<%= @interface %>
 BOOTPROTO=<%= @bootproto %>
-<% if @macaddress and @macaddress != '' %>HWADDR=<%= @macaddress %>
+<% if @manage_hwaddr and @macaddress and @macaddress != '' -%>
+HWADDR=<%= @macaddress %>
 <% end -%>
 ONBOOT=<%= @onboot %>
 HOTPLUG=<%= @onboot %>


### PR DESCRIPTION
Inspired by https://github.com/razorsedge/puppet-network/pull/42. However since nothing happened with that pull request I've created my own take on it. Tried to cherry-pick @divansantana commit however it failed because of some structural changes that would require me to patch it to even work.

Parameter manage_hwaddr is set true as a default which keeps the current defaults. Setting it to false removes the HWADDR line in ifcfg-X.