### PR TITLE
Add macaddress/hwaddr parameter to network::if::bridge

### DIFF
--- a/manifests/if/bridge.pp
+++ b/manifests/if/bridge.pp
@@ -8,6 +8,7 @@
 #   $bridge       - required - bridge interface name
 #   $mtu          - optional
 #   $ethtool_opts - optional
+#   $macaddress   - optional
 #
 # === Actions:
 #
@@ -32,7 +33,8 @@ define network::if::bridge (
   $ensure,
   $bridge,
   $mtu = undef,
-  $ethtool_opts = undef
+  $ethtool_opts = undef,
+  $macaddress = undef
 ) {
   # Validate our regular expressions
   $states = [ '^up$', '^down$' ]
@@ -43,7 +45,7 @@ define network::if::bridge (
     ipaddress    => '',
     netmask      => '',
     gateway      => '',
-    macaddress   => '',
+    macaddress   => $macaddress,
     bootproto    => 'none',
     ipv6address  => '',
     ipv6gateway  => '',

--- a/manifests/if/bridge.pp
+++ b/manifests/if/bridge.pp
@@ -40,12 +40,19 @@ define network::if::bridge (
   $states = [ '^up$', '^down$' ]
   validate_re($ensure, $states, '$ensure must be either "up" or "down".')
 
+  if $macaddress == undef {
+    $macaddy = ''
+  }
+  else {
+    $macaddy = $macaddress
+  }
+
   network_if_base { $title:
     ensure       => $ensure,
     ipaddress    => '',
     netmask      => '',
     gateway      => '',
-    macaddress   => $macaddress,
+    macaddress   => $macaddy,
     bootproto    => 'none',
     ipv6address  => '',
     ipv6gateway  => '',

--- a/manifests/if/bridge.pp
+++ b/manifests/if/bridge.pp
@@ -41,7 +41,7 @@ define network::if::bridge (
   validate_re($ensure, $states, '$ensure must be either "up" or "down".')
 
   if $macaddress == undef {
-    $macaddy = ''
+    $macaddy = '' # lint:ignore:empty_string_assignment
   }
   else {
     $macaddy = $macaddress

--- a/spec/defines/network_if_bridge_spec.rb
+++ b/spec/defines/network_if_bridge_spec.rb
@@ -58,6 +58,7 @@ describe 'network::if::bridge', :type => 'define' do
       :bridge       => 'br55',
       :mtu          => '9000',
       :ethtool_opts => 'speed 1000 duplex full autoneg off',
+      :macaddress   => '00:00:00:00:00:00',
     }
     end
     let :facts do {
@@ -77,6 +78,7 @@ describe 'network::if::bridge', :type => 'define' do
       verify_contents(catalogue, 'ifcfg-eth1', [
         'DEVICE=eth1',
         'BOOTPROTO=none',
+        'HWADDR=00:00:00:00:00:00',
         'ONBOOT=no',
         'HOTPLUG=no',
         'TYPE=Ethernet',


### PR DESCRIPTION
In some cases you need to define the HWADDR in the ifcfg-eth? file, so this bridged interface can come up.