### PR TITLE
Change default value for hostanme in syscofig/network

### DIFF
--- a/spec/classes/network_global_spec.rb
+++ b/spec/classes/network_global_spec.rb
@@ -20,7 +20,7 @@ describe 'network::global', :type => 'class' do
     let(:params) {{}}
     let :facts do {
       :osfamily => 'RedHat',
-      :fqdn     => 'localhost.localdomain',
+      :hostname => 'localhost',
     }
     end
     it { should contain_class('network') }
@@ -36,7 +36,7 @@ describe 'network::global', :type => 'class' do
       verify_contents(catalogue, 'network.sysconfig', [
         'NETWORKING=yes',
         'NETWORKING_IPV6=no',
-        'HOSTNAME=localhost.localdomain',
+        'HOSTNAME=localhost',
       ])
     end
   end

--- a/templates/network.erb
+++ b/templates/network.erb
@@ -10,7 +10,7 @@ NETWORKING=yes
 <% end -%>
 <% end -%>
 <% if @hostname %>HOSTNAME=<%= @hostname %>
-<% else %>HOSTNAME=<%= scope.lookupvar('::fqdn') %>
+<% else %>HOSTNAME=<%= scope.lookupvar('::hostname') %>
 <% end -%>
 <% if @gateway %>GATEWAY=<%= @gateway %>
 <% end -%>


### PR DESCRIPTION
Hi,

right now the hostname in `/etc/sysconfig/network` is set to the values of the fact `::fqdn` if not defined.

Since the linux command `hostname` will pick this hostname up and displays the same for hostname as for `hostname -f` wich is used for the FQDN - i'd like to change this to the fact `::hostname` to bring back the default behaviour on linux 

Current behaviour
```
~# hostname
localhost.localdomain
~# hostname -f
localhost.localdomain
```
Proposed behaviour
```
~# hostname
localhost
~# hostname -f
localhost.localdomain
```


Best reagards 