### PR TITLE
ASM-2067 #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,15 @@ Normal interface - VLAN - static (minimal):
       netmask   => '255.255.255.0',
     }
 
+Using mac address instead of interface name - find interface by its macaddress and modify its configuration (supported for network::if::static and network::bond::slave resources only at the moment):
+
+    network::if::static { 'fe:fe:fe:aa:aa:aa':
+      ensure       => 'up',
+      ipaddress    => '1.2.3.6',
+      netmask      => '255.255.255.0',
+      gateway      => '1.2.3.1',
+    }
+
 Notes
 -----
 

--- a/manifests/bond/static.pp
+++ b/manifests/bond/static.pp
@@ -37,8 +37,9 @@
 #
 define network::bond::static (
   $ensure,
-  $ipaddress,
-  $netmask,
+  $ipaddress = undef,
+  $netmask = undef,
+  $vlanId = undef,
   $gateway = undef,
   $mtu = undef,
   $ethtool_opts = undef,
@@ -50,13 +51,15 @@ define network::bond::static (
   $ipv6peerdns = false,
   $dns1 = undef,
   $dns2 = undef,
-  $domain = undef
+  $domain = undef,
 ) {
   # Validate our regular expressions
   $states = [ '^up$', '^down$' ]
   validate_re($ensure, $states, '$ensure must be either "up" or "down".')
   # Validate our data
-  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  if $ipaddress {
+    if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  }
   if $ipv6address {
     if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
   }
@@ -64,62 +67,28 @@ define network::bond::static (
   validate_bool($ipv6init)
   validate_bool($ipv6peerdns)
 
+  $alreadyConfigured = $title in split($::interfaces, ',')
 
-  network_if_base { $title:
-    ensure       => $ensure,
-    ipaddress    => $ipaddress,
-    netmask      => $netmask,
-    gateway      => $gateway,
-    macaddress   => '',
-    bootproto    => 'none',
-    mtu          => $mtu,
-    ethtool_opts => $ethtool_opts,
-    bonding_opts => $bonding_opts,
-    peerdns      => $peerdns,
-    ipv6init     => $ipv6init,
-    ipv6address  => $ipv6address,
-    ipv6peerdns  => $ipv6peerdns,
-    ipv6gateway  => $ipv6gateway,
-    dns1         => $dns1,
-    dns2         => $dns2,
-    domain       => $domain,
-  }
-
-  # Only install "alias bondN bonding" on old OSs that support
-  # /etc/modprobe.conf.
-  case $::operatingsystem {
-    /^(RedHat|CentOS|OEL|OracleLinux|SLC|Scientific)$/: {
-      case $::operatingsystemrelease {
-        /^[45]/: {
-          augeas { "modprobe.conf_${title}":
-            context => '/files/etc/modprobe.conf',
-            changes => [
-              "set alias[last()+1] ${title}",
-              'set alias[last()]/modulename bonding',
-            ],
-            onlyif  => "match alias[*][. = '${title}'] size == 0",
-            before  => Network_if_base[$title],
-          }
-        }
-        default: {}
-      }
+  if !$alreadyConfigured {
+    network_if_base { $title:
+      ensure       => $ensure,
+      ipaddress    => $ipaddress,
+      netmask      => $netmask,
+      gateway      => $gateway,
+      vlanId       => $vlanId,
+      macaddress   => '',
+      bootproto    => 'none',
+      mtu          => $mtu,
+      ethtool_opts => $ethtool_opts,
+      bonding_opts => $bonding_opts,
+      peerdns      => $peerdns,
+      ipv6init     => $ipv6init,
+      ipv6address  => $ipv6address,
+      ipv6peerdns  => $ipv6peerdns,
+      ipv6gateway  => $ipv6gateway,
+      dns1         => $dns1,
+      dns2         => $dns2,
+      domain       => $domain,
     }
-    'Fedora': {
-      case $::operatingsystemrelease {
-        /^(1|2|3|4|5|6|7|8|9|10|11)$/: {
-          augeas { "modprobe.conf_${title}":
-            context => '/files/etc/modprobe.conf',
-            changes => [
-              "set alias[last()+1] ${title}",
-              'set alias[last()]/modulename bonding',
-            ],
-            onlyif  => "match alias[*][. = '${title}'] size == 0",
-            before  => Network_if_base[$title],
-          }
-        }
-        default: {}
-      }
-    }
-    default: {}
   }
 } # define network::bond::static

--- a/manifests/bond/vlan.pp
+++ b/manifests/bond/vlan.pp
@@ -1,0 +1,65 @@
+# == Definition: network::bond::vlan
+#
+define network::bond::vlan (
+  $ensure,
+  $bootproto = 'none',
+  $ipaddress,
+  $netmask,
+  $vlanId,
+  $gateway,
+  $macaddress = '',
+  $mtu = undef,
+  $ethtool_opts = undef,
+  $bonding_opts = 'miimon=100',
+  $peerdns = false,
+  $ipv6init = false,
+  $ipv6address = undef,
+  $ipv6gateway = undef,
+  $ipv6peerdns = false,
+  $dns1 = undef,
+  $dns2 = undef,
+  $domain = undef
+) {
+
+  $states = [ '^up$', '^down$' ]
+  validate_re($ensure, $states, '$ensure must be either "up" or "down".')
+
+  if ! $vlanId { fail("vlanId must be passed for this resource type!") }
+  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  if $ipv6address {
+    if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
+  }
+  validate_bool($ipv6init)
+  validate_bool($ipv6peerdns)
+
+  $onboot = $ensure ? {
+    'up'    => 'yes',
+    'down'  => 'no',
+    default => undef,
+  }
+
+  $interface = $name
+
+  #include '::network'
+
+  $alreadyConfigured = $name in split($::interfaces, ',')
+
+  if !$alreadyConfigured {
+    exec { "/bin/echo 'alias ifcfg-${interface} bonding' >> /etc/modprobe.d/bonding.conf":
+    }->
+    exec { "reload modprobe after ${interface} is added to bonding module config":
+      command => '/sbin/modprobe -r bonding; /sbin/modprobe bonding',
+    }->
+    file { "ifcfg-${interface}.${vlanId}}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}.${vlanId}",
+      content => template('network/ifcfg-eth.erb'),
+      notify => Service['network'],
+    }
+  }
+
+
+} # define network::bond::vlan

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -50,8 +50,8 @@
 #
 define network::if::static (
   $ensure,
-  $ipaddress,
-  $netmask,
+  $ipaddress = undef,
+  $netmask = undef,
   $gateway = undef,
   $ipv6address = undef,
   $ipv6init = false,
@@ -70,7 +70,9 @@ define network::if::static (
   $scope = undef
 ) {
   # Validate our data
-  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  if $ipaddress {
+    if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  }
   if $ipv6address {
     if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
   }
@@ -89,26 +91,30 @@ define network::if::static (
   validate_bool($peerdns)
   validate_bool($ipv6peerdns)
 
-  network_if_base { $title:
-    ensure       => $ensure,
-    ipv6init     => $ipv6init,
-    ipaddress    => $ipaddress,
-    ipv6address  => $ipv6address,
-    netmask      => $netmask,
-    gateway      => $gateway,
-    ipv6gateway  => $ipv6gateway,
-    ipv6autoconf => $ipv6autoconf,
-    macaddress   => $macaddy,
-    bootproto    => 'none',
-    userctl      => $userctl,
-    mtu          => $mtu,
-    ethtool_opts => $ethtool_opts,
-    peerdns      => $peerdns,
-    ipv6peerdns  => $ipv6peerdns,
-    dns1         => $dns1,
-    dns2         => $dns2,
-    domain       => $domain,
-    linkdelay    => $linkdelay,
-    scope        => $scope,
+  $numConfiguredInterfaces = inline_template('<% count = 0 %><% interfaces.split(",").each do |ifn| %><% if name == scope.lookupvar("macaddress_#{ifn}") || name.downcase == scope.lookupvar("macaddress_#{ifn}") %><% count += 1 %><% end %><% end %><%= count %>')
+
+  if $numConfiguredInterfaces < 1 {
+    network_if_base { $title:
+      ensure       => $ensure,
+      ipv6init     => $ipv6init,
+      ipaddress    => $ipaddress,
+      ipv6address  => $ipv6address,
+      netmask      => $netmask,
+      gateway      => $gateway,
+      ipv6gateway  => $ipv6gateway,
+      ipv6autoconf => $ipv6autoconf,
+      macaddress   => $macaddy,
+      bootproto    => 'none',
+      userctl      => $userctl,
+      mtu          => $mtu,
+      ethtool_opts => $ethtool_opts,
+      peerdns      => $peerdns,
+      ipv6peerdns  => $ipv6peerdns,
+      dns1         => $dns1,
+      dns2         => $dns2,
+      domain       => $domain,
+      linkdelay    => $linkdelay,
+      scope        => $scope,
+    }
   }
 } # define network::if::static

--- a/manifests/if/vlan.pp
+++ b/manifests/if/vlan.pp
@@ -1,0 +1,58 @@
+define network::if::vlan (
+  $ensure,
+  $vlanId,
+  $ipaddress,
+  $netmask,
+  $macaddress      = undef,
+  $gateway         = undef,
+  $bootproto       = 'none',
+  $userctl         = false,
+  $mtu             = undef,
+  $ethtool_opts    = undef,
+  $peerdns         = false,
+  $ipv6peerdns     = false,
+  $dns1            = undef,
+  $dns2            = undef,
+  $domain          = undef,
+  $linkdelay       = undef,
+  $scope           = undef,
+) {
+# Validate data
+  $states = [ '^up$', '^down$' ]
+  validate_re($ensure, $states, '$ensure must be either "up" or "down".')
+
+  if $ipaddress {
+    if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  }
+  if $ipv6address {
+    if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
+  }
+
+  if is_mac_address($name){
+    $interface = inline_template('<% interfaces.split(",").each do |ifn| %><% if name == scope.lookupvar("macaddress_#{ifn}") || name.downcase == scope.lookupvar("macaddress_#{ifn}") %><%= ifn %><% end %><% end %>')
+    if !$interface {
+      fail('Could not find the interface name for the given macaddress...')
+    }
+  } else {
+    $interface = $name
+  }
+
+  $onboot = $ensure ? {
+    'up'    => 'yes',
+    'down'  => 'no',
+    default => undef,
+  }
+
+  $numConfiguredInterfaces = inline_template('<% count = 0 %><% interfaces.split(",").each do |ifn| %><% if name == scope.lookupvar("macaddress_#{ifn}") || name.downcase == scope.lookupvar("macaddress_#{ifn}") %><% count += 1 %><% end %><% end %><%= count %>')
+
+  if $numConfiguredInterfaces < 1 {
+    file { "ifcfg-${interface}.${vlanId}}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/ifcfg-${interface}.${vlanId}",
+      content => template('network/ifcfg-eth.erb'),
+    }
+  }
+} # define network::if::vlan

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -1,13 +1,17 @@
 ###
 ### File managed by Puppet
 ###
-DEVICE=<%= @interface %>
 BOOTPROTO=<%= @bootproto %>
 <% if @macaddress and @macaddress != '' %>HWADDR=<%= @macaddress %>
 <% end -%>
 ONBOOT=<%= @onboot %>
 HOTPLUG=<%= @onboot %>
-TYPE=Ethernet
+<% if @isethernet %>TYPE=Ethernet<% end -%>
+<% if @vlanId and @vlanId != '' %>VLAN=yes
+DEVICE=<%= @interface %>.<%= @vlanId %>
+<% else %>
+DEVICE=<%= @interface %>
+<% end -%>
 <% if @ipaddress and @ipaddress != '' %>IPADDR=<%= @ipaddress %>
 <% end -%>
 <% if @netmask and @netmask != '' %>NETMASK=<%= @netmask %>

--- a/templates/network.erb
+++ b/templates/network.erb
@@ -15,6 +15,7 @@ NETWORKING=yes
 <% if @gateway %>GATEWAY=<%= @gateway %>
 <% end -%>
 <% if @gatewaydev %>GATEWAYDEV=<%= @gatewaydev %>
+<% elsif @gatewaydev_from_mac %>GATEWAYDEV=<%= @gatewaydev_from_mac %>
 <% end -%>
 <% if @nisdomain %>NISDOMAIN=<%= @nisdomain %>
 <% end -%>


### PR DESCRIPTION
modified the module to take macaddress as the title/name of the resource instead of requiring the interface name

instead of creating new fact and waiting for the second puppet agent run, inline_template function is used to do fact fetching and manipulation

clean up files that are no longer needed

final modifications done

modification to handle the gatewaydevice by macaddress

modified the checking already configured network settings more intuitive

additional bug fixes and prevention from misconfigurations