### PR TITLE
Fix for wrong ensure_package parameter type.

### DIFF
--- a/manifests/bridge.pp
+++ b/manifests/bridge.pp
@@ -47,7 +47,7 @@ define network::bridge (
   validate_bool($stp)
   validate_bool($ipv6init)
 
-  ensure_packages('bridge-utils')
+  ensure_packages(['bridge-utils'])
 
   include '::network'
 

--- a/manifests/bridge/dynamic.pp
+++ b/manifests/bridge/dynamic.pp
@@ -49,7 +49,7 @@ define network::bridge::dynamic (
   validate_bool($userctl)
   validate_bool($stp)
 
-  ensure_packages('bridge-utils')
+  ensure_packages(['bridge-utils'])
 
   include '::network'
 

--- a/manifests/bridge/static.pp
+++ b/manifests/bridge/static.pp
@@ -82,7 +82,7 @@ define network::bridge::static (
   validate_bool($ipv6init)
   validate_bool($ipv6peerdns)
 
-  ensure_packages('bridge-utils')
+  ensure_packages(['bridge-utils'])
 
   include '::network'
 


### PR DESCRIPTION
Use array type parameter in ensure_package function instead of string for old stdlib module compatibility. In old version puppet-stdlib modules(<3.2.1 or <4.2.0), ensure_package function only accept parameter
of array type. This will cause a parameter type error if the stdlib module used is not that up to date.

The puppet-stdlib module enhanced the ensure_package function's allowed paramter type since the commit 735db82bef56bf939c971ab76a66647269d6ae35. Rather than modify the dependencies in the metadata.json, I think it's better to modify the parameter type in the ensure_package function call for more compatible code.