### PR TITLE
Remove duplicate linkdelay variable declaration.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,7 +117,6 @@ define network_if_base (
   $dns2            = undef,
   $domain          = undef,
   $bridge          = undef,
-  $linkdelay       = undef,
   $scope           = undef,
   $linkdelay       = undef,
   $check_link_down = false


### PR DESCRIPTION
Remove  duplicate linkdelay variable declaration. 