### PR TITLE
network::if::static:  Add VLAN capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Normal interface - VLAN - static (minimal):
 
     network::if::static { 'eth0.330':
       ensure    => 'up',
+      vlan      => true,
       ipaddress => '10.2.3.248',
       netmask   => '255.255.255.0',
     }

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -53,6 +53,7 @@ define network::if::static (
   $ipaddress,
   $netmask,
   $gateway = undef,
+  $vlan = false,
   $ipv6address = undef,
   $ipv6init = false,
   $ipv6gateway = undef,
@@ -83,6 +84,7 @@ define network::if::static (
     $macaddy = $macaddress
   }
   # Validate booleans
+  validate_bool($vlan)
   validate_bool($userctl)
   validate_bool($ipv6init)
   validate_bool($ipv6autoconf)
@@ -96,6 +98,7 @@ define network::if::static (
     ipv6address  => $ipv6address,
     netmask      => $netmask,
     gateway      => $gateway,
+    vlan         => $vlan,
     ipv6gateway  => $ipv6gateway,
     ipv6autoconf => $ipv6autoconf,
     macaddress   => $macaddy,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,6 +100,7 @@ define network_if_base (
   $netmask,
   $macaddress,
   $gateway         = undef,
+  $vlan            = false,
   $ipv6address     = undef,
   $ipv6gateway     = undef,
   $ipv6init        = false,
@@ -123,6 +124,7 @@ define network_if_base (
   $check_link_down = false
 ) {
   # Validate our booleans
+  validate_bool($vlan)
   validate_bool($userctl)
   validate_bool($isalias)
   validate_bool($peerdns)
@@ -163,6 +165,10 @@ define network_if_base (
     $onboot = $ensure ? {
       'up'    => 'yes',
       'down'  => 'no',
+      default => undef,
+    }
+    $vlanyes = $vlan ? {
+      true    => 'yes',
       default => undef,
     }
     $iftemplate = template('network/ifcfg-eth.erb')

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -8,6 +8,8 @@ BOOTPROTO=<%= @bootproto %>
 ONBOOT=<%= @onboot %>
 HOTPLUG=<%= @onboot %>
 TYPE=Ethernet
+<% if @vlanyes %>VLAN=<%= @vlanyes %>
+<% end -%>
 <% if @ipaddress and @ipaddress != '' %>IPADDR=<%= @ipaddress %>
 <% end -%>
 <% if @netmask and @netmask != '' %>NETMASK=<%= @netmask %>


### PR DESCRIPTION
Adds missing VLAN capability to network::if::static.

The existing documentation for using VLAN:s on static interfaces says to
instantiate network::global with the parameter vlan set to yes, such as:
    class{'network::global':
      vlan => 'yes'
    }

This isn't sufficient. ifcfg-$ifname requires also the parameter
'VLAN=yes' defined, for a VLAN interface.

With this approach, that parameter is explicitly defined to
network::static::if, such as:

```
'network::static::if' { 'eth0.330':
  ensure    => 'up',
  vlan      => true,
  ipaddress => '10.2.3.248',
  netmask   => '255.255.255.0',
}
```

This makes it abundantly clear what's going on.
