### PR TITLE
Add alias and ipv6 secondary funtionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,22 @@ Global network setting with IPv6 enabled with optional default device for IPv6 t
       ipv6defaultdev => 'eth1',
     }
 
-
 Normal interface - static (minimal):
 
     network::if::static { 'eth0':
       ensure    => 'up',
       ipaddress => '1.2.3.248',
       netmask   => '255.255.255.128',
+    }
+
+Normal interface - static (using un-docmented alias addresses):
+
+    network::if::static { 'eth0':
+      ensure    => 'up',
+      ipaddress => '1.2.3.248',
+      netmask   => '255.255.255.128',
+      aliases   => [ { ipaddr => '1.2.3.249', netmask => '255.255.255.128' },
+                     { ipaddr => '1.2.3.250', prefix  => '25' } ],
     }
 
 Normal interface - static:
@@ -67,6 +76,22 @@ Normal interface - static:
       ipv6gateway  => '123:4567:89ab:cdef:123:4567:89ab:1',
       mtu          => '9000',
       ethtool_opts => 'autoneg off speed 1000 duplex full',
+    }
+
+Normal interface - static - with IPv6 Secondaries:
+
+    network::if::static { 'eth1':
+      ensure       => 'up',
+      ipaddress    => '1.2.3.4',
+      netmask      => '255.255.255.0',
+      gateway      => '1.2.3.1',
+      macaddress   => 'fe:fe:fe:aa:aa:aa',
+      ipv6init     => true,
+      ipv6address  => '123:4567:89ab:cdef:123:4567:89ab:cdef/64',
+      ipv6gateway  => '123:4567:89ab:cdef:123:4567:89ab:1',
+      mtu          => '9000',
+      ethtool_opts => 'autoneg off speed 1000 duplex full',
+      ipv6sec      => '123:4567:89ab:cdef:123:4567:89ab:cdf0/64 123:4567:89ab:cdef::1:1/64
     }
 
 Normal interface - dhcp (minimal):

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -22,6 +22,9 @@
 #   $dns2         - optional
 #   $domain       - optional
 #   $scope        - optional
+#   $linkdelay    - optional
+#   $ipv6sec      - optional
+#   $aliases      - optional
 #
 # === Actions:
 #
@@ -67,7 +70,12 @@ define network::if::static (
   $dns2 = undef,
   $domain = undef,
   $linkdelay = undef,
+<<<<<<< HEAD
   $scope = undef
+=======
+  $ipv6sec = undef,
+  $aliases = [],
+>>>>>>> Add alias and ipv6 secondary funtionality
 ) {
   # Validate our data
   if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
@@ -109,6 +117,11 @@ define network::if::static (
     dns2         => $dns2,
     domain       => $domain,
     linkdelay    => $linkdelay,
+<<<<<<< HEAD
     scope        => $scope,
+=======
+    ipv6sec      => $ipv6sec,
+    aliases      => $aliases,
+>>>>>>> Add alias and ipv6 secondary funtionality
   }
 } # define network::if::static

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,9 @@ class network {
 #   $scope           - optional
 #   $linkdelay       - optional
 #   $check_link_down - optional
+#   $linkdelay       - optional
+#   $ipv6sec         - optional
+#   $aliases         - optional
 #
 # === Actions:
 #
@@ -120,7 +123,9 @@ define network_if_base (
   $linkdelay       = undef,
   $scope           = undef,
   $linkdelay       = undef,
-  $check_link_down = false
+  $check_link_down = false,
+  $ipv6sec         = undef,
+  $aliases         = [],
 ) {
   # Validate our booleans
   validate_bool($userctl)

--- a/spec/defines/network_if_static_spec.rb
+++ b/spec/defines/network_if_static_spec.rb
@@ -90,8 +90,11 @@ describe 'network::if::static', :type => 'define' do
       :ipv6peerdns  => true,
       :ipv6address  => '123:4567:89ab:cdef:123:4567:89ab:cdef/64',
       :ipv6gateway  => '123:4567:89ab:cdef:123:4567:89ab:1',
+      :ipv6sec      => '123:4567:89ab:cdef:123:4567:89ab:cdf0/64 123:4567:89ab:cdef:123:4567:89ab:cdf1/64',
       :linkdelay    => '5',
       :scope        => 'peer 1.2.3.1',
+      :aliases      => [ { 'ipaddr' => '1.2.3.5', 'netmask' => '255.255.255.0' },
+                         { 'ipaddr' => '1.2.3.6', 'prefix' => '24' } ],
     }
     end
     let :facts do {
@@ -130,9 +133,14 @@ describe 'network::if::static', :type => 'define' do
         'IPV6ADDR=123:4567:89ab:cdef:123:4567:89ab:cdef/64',
         'IPV6_DEFAULTGW=123:4567:89ab:cdef:123:4567:89ab:1',
         'IPV6_PEERDNS=yes',
+        'IPV6ADDR_SECONDARIES=123:4567:89ab:cdef:123:4567:89ab:cdf0/64 123:4567:89ab:cdef:123:4567:89ab:cdf1/64',
         'LINKDELAY=5',
         'SCOPE="peer 1.2.3.1"',
         'NM_CONTROLLED=no',
+        'IPADDR1=1.2.3.5',
+        'NETMASK1=255.255.255.0',
+        'IPADDR2=1.2.3.6',
+        'PREFIX2=24',
       ])
     end
     it { should contain_service('network') }

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -45,6 +45,8 @@ IPV6INIT=yes
 <% if !@ipv6peerdns %>IPV6_PEERDNS=no
 <% else %>IPV6_PEERDNS=yes
 <% end -%>
+<% if @ipv6sec %>IPV6ADDR_SECONDARIES=<%= @ipv6sec %>
+<% end -%>
 <% end -%>
 <% if @bridge %>BRIDGE=<%= @bridge %>
 <% end -%>
@@ -58,3 +60,12 @@ check_link_down() {
 }
 <% end -%>
 NM_CONTROLLED=no
+<% if !@aliases.empty? -%>
+<% num = 1 -%>
+<%   @aliases.each do |a| -%>
+<%     a.sort_by {|param,value| param}.each do |param,value| -%>
+<%= param.upcase %><%= num %>=<%= value %>
+<%     end -%>
+<% num += 1 -%>
+<%   end -%>
+<% end -%>


### PR DESCRIPTION
This provides the funtionality to add alias addresses to devices
without creating additional NICs, reading through the network scripts
on RHEL based systems. This appears to be the easiest way to add this
functionality rather than creating lots of alias NICs.

Also adds funtionality fo IPv6 secondaries.