### PR TITLE
Don't require ipaddress

### DIFF
--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -55,8 +55,8 @@
 #
 define network::if::static (
   $ensure,
-  $ipaddress,
-  $netmask,
+  $ipaddress = undef,
+  $netmask = undef,
   $gateway = undef,
   $ipv6address = undef,
   $ipv6init = false,
@@ -80,7 +80,9 @@ define network::if::static (
   $metric = undef
 ) {
   # Validate our data
-  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  if $ipaddress {
+    if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  }
   if is_array($ipv6address) {
     if size($ipv6address) > 0 {
       validate_ip_address { $ipv6address: }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,8 +103,8 @@ class network {
 #
 define network_if_base (
   $ensure,
-  $ipaddress,
-  $netmask,
+  $ipaddress       = undef,
+  $netmask         = undef,
   $macaddress,
   $manage_hwaddr   = true,
   $gateway         = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,9 +103,9 @@ class network {
 #
 define network_if_base (
   $ensure,
+  $macaddress,
   $ipaddress       = undef,
   $netmask         = undef,
-  $macaddress,
   $manage_hwaddr   = true,
   $gateway         = undef,
   $noaliasrouting  = false,


### PR DESCRIPTION
For my use case at work, I needed to manage base interfaces which were configured without an IP address and netmask (to enable VLAN interfaces). I imagine I'm not the only one, so I thought I would create a PR for this. I also imagine I may be missing some finer point, so if this isn't acceptable, I understand.

This PR only removes the requirement for IP address and netmask. It still checks if an IP address is valid, etc. It looks like the tests still pass without modification.

If I missed something or you need more information, please let me know and I will do what I can to fix.
