### PR TITLE
Make mac address optional for bond slave

### DIFF
--- a/manifests/bond/slave.pp
+++ b/manifests/bond/slave.pp
@@ -4,7 +4,7 @@
 #
 # === Parameters:
 #
-#   $macaddress   - required
+#   $macaddress   - optional
 #   $master       - required
 #   $ethtool_opts - optional
 #
@@ -32,15 +32,15 @@
 # Copyright (C) 2011 Mike Arnold, unless otherwise noted.
 #
 define network::bond::slave (
-  $macaddress,
   $master,
+  $macaddress = undef,
   $ethtool_opts = undef,
   $zone = undef,
   $defroute = undef,
   $metric = undef
 ) {
   # Validate our data
-  if ! is_mac_address($macaddress) {
+  if $macaddress and ! is_mac_address($macaddress) {
     fail("${macaddress} is not a MAC address.")
   }
 

--- a/spec/defines/network_bond_slave_spec.rb
+++ b/spec/defines/network_bond_slave_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'network::bond::slave', :type => 'define' do
 
-  context 'incorrect value: ipaddress' do
+  context 'incorrect value: macaddress' do
     let(:title) { 'eth6' }
     let :params do {
       :macaddress => '123456',
@@ -14,6 +14,20 @@ describe 'network::bond::slave', :type => 'define' do
     it 'should fail' do
       expect {should contain_file('ifcfg-eth6')}.to raise_error(Puppet::Error, /123456 is not a MAC address./)
     end
+  end
+
+  context 'optional value: macaddress' do
+    let(:title) { 'eth6' }
+    let :facts do {
+      :osfamily        => 'RedHat',
+      :macaddress_eth1 => 'fe:fe:fe:aa:aa:aa',
+    }
+    end
+    let :params do {
+      :master     => 'bond0',
+    }
+    end
+    it { should contain_file('ifcfg-eth6').without_content('HWADDR=') }
   end
 
   context 'required parameters' do

--- a/templates/ifcfg-bond.erb
+++ b/templates/ifcfg-bond.erb
@@ -2,7 +2,8 @@
 ### File managed by Puppet
 ###
 DEVICE=<%= @interface %>
-HWADDR=<%= @macaddress %>
+<% if @macaddress and @macaddress != '' %>HWADDR=<%= @macaddress %>
+<% end -%>
 MASTER=<%= @master %>
 SLAVE=yes
 TYPE=Ethernet


### PR DESCRIPTION
Fix spec test for optional macaddress
(and fix spec test context name for incorrect macaddress value)

This addresses issue #89 
