### PR TITLE
Update bonding for extra parameters

### DIFF
--- a/manifests/bond/slave.pp
+++ b/manifests/bond/slave.pp
@@ -4,9 +4,15 @@
 #
 # === Parameters:
 #
-#   $macaddress   - required
 #   $master       - required
+#   $macaddress   - optional
 #   $ethtool_opts - optional
+#   $zone         - optional
+#   $defroute     - optional
+#   $metric       - optional
+#   $userctl      - optional - defaults to false
+#   $bootproto    - optional
+#   $onboot       - optional
 #
 # === Actions:
 #
@@ -32,17 +38,21 @@
 # Copyright (C) 2011 Mike Arnold, unless otherwise noted.
 #
 define network::bond::slave (
-  $macaddress,
   $master,
+  $macaddress = undef,
   $ethtool_opts = undef,
   $zone = undef,
   $defroute = undef,
-  $metric = undef
+  $metric = undef,
+  $userctl = false,
+  $bootproto = undef,
+  $onboot = undef,
 ) {
   # Validate our data
-  if ! is_mac_address($macaddress) {
+  if $macaddress and ! is_mac_address($macaddress) {
     fail("${macaddress} is not a MAC address.")
   }
+  validate_bool($userctl)
 
   include '::network'
 

--- a/manifests/bond/static.pp
+++ b/manifests/bond/static.pp
@@ -13,8 +13,9 @@
 #   $ethtool_opts - optional
 #   $bonding_opts - optional
 #   $zone         - optional
-#   $metric       - optional
 #   $defroute     - optional
+#   $metric       - optional
+#   $userctl      - optional
 #
 # === Actions:
 #
@@ -56,7 +57,8 @@ define network::bond::static (
   $domain = undef,
   $zone = undef,
   $defroute = undef,
-  $metric = undef
+  $metric = undef,
+  $userctl = undef,
 ) {
   # Validate our regular expressions
   $states = [ '^up$', '^down$' ]
@@ -69,7 +71,6 @@ define network::bond::static (
   # Validate booleans
   validate_bool($ipv6init)
   validate_bool($ipv6peerdns)
-
 
   network_if_base { $title:
     ensure       => $ensure,
@@ -92,6 +93,7 @@ define network::bond::static (
     zone         => $zone,
     defroute     => $defroute,
     metric       => $metric,
+    userctl      => $userctl,
   }
 
   # Only install "alias bondN bonding" on old OSs that support

--- a/spec/defines/network_bond_slave_spec.rb
+++ b/spec/defines/network_bond_slave_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'network::bond::slave', :type => 'define' do
 
-  context 'incorrect value: ipaddress' do
+  context 'incorrect value: macaddress' do
     let(:title) { 'eth6' }
     let :params do {
       :macaddress => '123456',
@@ -19,7 +19,6 @@ describe 'network::bond::slave', :type => 'define' do
   context 'required parameters' do
     let(:title) { 'eth1' }
     let :params do {
-      :macaddress => 'fe:fe:fe:aa:aa:a1',
       :master     => 'bond0',
     }
     end
@@ -41,7 +40,6 @@ describe 'network::bond::slave', :type => 'define' do
     it 'should contain File[ifcfg-eth1] with required contents' do
       verify_contents(catalogue, 'ifcfg-eth1', [
         'DEVICE=eth1',
-        'HWADDR=fe:fe:fe:aa:aa:a1',
         'MASTER=bond0',
         'SLAVE=yes',
         'TYPE=Ethernet',
@@ -57,6 +55,10 @@ describe 'network::bond::slave', :type => 'define' do
       :macaddress   => 'ef:ef:ef:ef:ef:ef',
       :master       => 'bond0',
       :ethtool_opts => 'speed 1000 duplex full autoneg off',
+      :userctl      => true,
+      :bootproto    => 'dhcp',
+      :onboot       => 'yes',
+
     }
     end
     let :facts do {
@@ -82,6 +84,9 @@ describe 'network::bond::slave', :type => 'define' do
         'SLAVE=yes',
         'TYPE=Ethernet',
         'ETHTOOL_OPTS="speed 1000 duplex full autoneg off"',
+        'BOOTPROTO=dhcp',
+        'ONBOOT=yes',
+        'USERCTL=yes',
         'NM_CONTROLLED=no',
       ])
     end

--- a/spec/defines/network_bond_static_spec.rb
+++ b/spec/defines/network_bond_static_spec.rb
@@ -148,6 +148,7 @@ describe 'network::bond::static', :type => 'define' do
       :defroute     => 'yes',
       :metric       => '10',
       :zone         => 'trusted',
+      :userctl      => true,
     }
     end
     let :facts do {
@@ -181,6 +182,7 @@ describe 'network::bond::static', :type => 'define' do
         'DNS1=3.4.5.6',
         'DNS2=5.6.7.8',
         'DOMAIN="somedomain.com"',
+        'USERCTL=yes',
         'IPV6INIT=yes',
         'IPV6ADDR=123:4567:89ab:cdef:123:4567:89ab:cdef/64',
         'IPV6_DEFAULTGW=123:4567:89ab:cdef:123:4567:89ab:1',

--- a/templates/ifcfg-bond.erb
+++ b/templates/ifcfg-bond.erb
@@ -2,7 +2,8 @@
 ### File managed by Puppet
 ###
 DEVICE=<%= @interface %>
-HWADDR=<%= @macaddress %>
+<% if @macaddress and @macaddress != '' %>HWADDR=<%= @macaddress %>
+<% end -%>
 MASTER=<%= @master %>
 SLAVE=yes
 TYPE=Ethernet
@@ -13,5 +14,11 @@ TYPE=Ethernet
 <% if @zone %>ZONE=<%= @zone %>
 <% end -%>
 <% if @metric %>METRIC=<%= @metric %>
+<% end -%>
+<% if @bootproto %>BOOTPROTO=<%= @bootproto %>
+<% end -%>
+<% if @onboot %>ONBOOT=<%= @onboot %>
+<% end -%>
+<% if @userctl %>USERCTL=yes
 <% end -%>
 NM_CONTROLLED=no


### PR DESCRIPTION
Changed macadress for bond slaves to be optional (if not provided, try to get value from facts); also added missing comment lines for previously added params.
Added explicit userctl, bootproto, onboot for bond slaves.
Added explicit userctl for static bonds (also reordered a couple params for consistency).
Updated templates; updated specs.
