### PR TITLE
Make RES_OPTIONS for single-request-reopen optional

### DIFF
--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -23,6 +23,7 @@
 #   $vlan           - optional - yes|no to enable VLAN kernel module
 #   $ipv6networking - optional - enables / disables IPv6 globally
 #   $nozeroconf     - optional
+#   $requestreopen  - optional - defaults to true
 #
 # === Actions:
 #
@@ -44,6 +45,7 @@
 #     vlan           => 'yes',
 #     ipv6networking => true,
 #     nozeroconf     => 'yes',
+#     requestreopen  => false,
 #   }
 #
 # === TODO:
@@ -67,7 +69,8 @@ class network::global (
   $nisdomain      = undef,
   $vlan           = undef,
   $ipv6networking = false,
-  $nozeroconf     = undef
+  $nozeroconf     = undef,
+  $requestreopen  = true
 ) {
   # Validate our data
   if $gateway {
@@ -78,14 +81,13 @@ class network::global (
   }
 
   validate_bool($ipv6networking)
+  validate_bool($requestreopen)
 
   # Validate our regular expressions
   if $vlan {
     $states = [ '^yes$', '^no$' ]
     validate_re($vlan, $states, '$vlan must be either "yes" or "no".')
   }
-
-  validate_bool($ipv6networking)
 
   include '::network'
 

--- a/spec/classes/network_global_spec.rb
+++ b/spec/classes/network_global_spec.rb
@@ -39,6 +39,7 @@ describe 'network::global', :type => 'class' do
         'NETWORKING=yes',
         'NETWORKING_IPV6=no',
         'HOSTNAME=localhost.localdomain',
+        'RES_OPTIONS=\"single-request-reopen\"',
       ])
     end
     it { should_not contain_exec('hostnamectl set-hostname') }
@@ -71,6 +72,7 @@ describe 'network::global', :type => 'class' do
         'NISDOMAIN=myNisDomain',
         'VLAN=yes',
         'NOZEROCONF=yes',
+        'RES_OPTIONS=\"single-request-reopen\"',
       ])
     end
     it { should contain_exec('hostnamectl set-hostname').with(
@@ -155,6 +157,16 @@ describe 'network::global', :type => 'class' do
 
   end
 
+    context 'requestreopen = foo' do
+      let(:params) {{ :requestreopen => 'foo' }}
+
+      it 'should fail' do
+        expect { 
+          should raise_error(Puppet::Error, /$requestreopen is not a boolean.  It looks to be a String./)
+        }
+      end
+    end
+
   context 'on a supported operatingsystem, custom parameters' do
     let :params do {
       :hostname       => 'myHostname',
@@ -166,6 +178,7 @@ describe 'network::global', :type => 'class' do
       :ipv6networking => true,
       :ipv6gateway    => '123:4567:89ab:cdef:123:4567:89ab:1',
       :ipv6defaultdev => 'eth3',
+      :requestreopen  => false,
     }
     end
     let :facts do {

--- a/templates/network.erb
+++ b/templates/network.erb
@@ -22,4 +22,5 @@ NETWORKING=yes
 <% end -%>
 <% if @nozeroconf %>NOZEROCONF=<%= @nozeroconf %>
 <% end -%>
-RES_OPTIONS="single-request-reopen"
+<% if @requestreopen %>RES_OPTIONS="single-request-reopen"
+<% end -%>


### PR DESCRIPTION
We don't need single-request-reopen and we don't want all the network interface to refresh based on an unneeded change. Defaulted to true so as not to change status quo.
