### PR TITLE
added support for bonding interfaces without ip addresses

### DIFF
--- a/manifests/bond/static.pp
+++ b/manifests/bond/static.pp
@@ -40,8 +40,8 @@
 #
 define network::bond::static (
   $ensure,
-  $ipaddress,
-  $netmask,
+  $ipaddress = undef,
+  $netmask = undef,
   $gateway = undef,
   $mtu = undef,
   $ethtool_opts = undef,
@@ -62,7 +62,9 @@ define network::bond::static (
   $states = [ '^up$', '^down$' ]
   validate_re($ensure, $states, '$ensure must be either "up" or "down".')
   # Validate our data
-  if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  if $ipaddress {
+    if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
+  }
   if $ipv6address {
     if ! is_ip_address($ipv6address) { fail("${ipv6address} is not an IPv6 address.") }
   }


### PR DESCRIPTION
Thanks for the great module, I did just a small change which should not hurt anyone. When using vlan on bonding interfaces, you may not want the bonding interface to have an ip address.
