### PR TITLE
ensure_packages expects an array

### DIFF
--- a/manifests/bridge/static.pp
+++ b/manifests/bridge/static.pp
@@ -82,7 +82,7 @@ define network::bridge::static (
   validate_bool($ipv6init)
   validate_bool($ipv6peerdns)
 
-  ensure_packages('bridge-utils')
+  ensure_packages(['bridge-utils'])
 
   include '::network'
 


### PR DESCRIPTION
Using the following code

network::bridge::static { 'br0':
  ensure    => 'up',
  ipaddress => '10.101.0.0',
  netmask   => '255.255.0.0',
}

results in the following error

Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, ensure_packages(): Requires array given (String) at /home/centos/openshift/modules/network/manifests/bridge/static.pp:85:3  at /home/centos/openshift/manifests/site.pp:10 on node openshift-node-2.localdomain