### PR TITLE
added support for policy based routing

### DIFF
--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -40,27 +40,58 @@
 # Copyright (C) 2011 Mike Arnold, unless otherwise noted.
 #
 define network::route (
-  $ipaddress,
-  $netmask,
-  $gateway
+  $ipaddress   = [],
+  $netmask     = [],
+  $gateway     = [],
+  $ipv4_routes = [],
+  $ipv6_routes = [],
 ) {
   # Validate our arrays
   validate_array($ipaddress)
   validate_array($netmask)
   validate_array($gateway)
+  validate_array($ipv4_routes)
+  validate_array($ipv6_routes)
 
   include '::network'
 
   $interface = $name
 
-  file { "route-${interface}":
-    ensure  => 'present',
-    mode    => '0644',
-    owner   => 'root',
-    group   => 'root',
-    path    => "/etc/sysconfig/network-scripts/route-${interface}",
-    content => template('network/route-eth.erb'),
-    before  => File["ifcfg-${interface}"],
-    notify  => Service['network'],
+  if empty($ipaddress) and (!empty($ipv4_routes) or !empty($ipv6_routes)) {
+    if ! empty($ipv4_routes) {
+      file { "route-${interface}":
+        ensure  => 'present',
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+        path    => "/etc/sysconfig/network-scripts/route-${interface}",
+        content => template('network/route-eth-v4.erb'),
+        before  => File["ifcfg-${interface}"],
+        notify  => Service['network'],
+      }
+    }
+    if ! empty($ipv6_routes) {
+      file { "route6-${interface}":
+        ensure  => 'present',
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+        path    => "/etc/sysconfig/network-scripts/route6-${interface}",
+        content => template('network/route-eth-v6.erb'),
+        before  => File["ifcfg-${interface}"],
+        notify  => Service['network'],
+      }
+    }
+  } else {
+    file { "route-${interface}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/route-${interface}",
+      content => template('network/route-eth.erb'),
+      before  => File["ifcfg-${interface}"],
+      notify  => Service['network'],
+    }
   }
 } # define network::route

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -1,0 +1,75 @@
+# == Definition: network::rule
+#
+# Configures /etc/sysconfig/networking-scripts/rule-$name.
+#
+# === Parameters:
+#
+#   $ipv4_rules
+#   $ipv6_rules
+#
+# === Actions:
+#
+# Deploys the file /etc/sysconfig/network-scripts/rule-$name.
+#
+# === Requires:
+#
+#   File["ifcfg-$name"]
+#   Service['network']
+#
+# === Sample Usage:
+#
+#   network::route { 'eth0':
+#     ipv4_rules => [{
+#       iif   => 'eth0',
+#       table => 1,
+#     },{
+#       from  => '192.168.200.100',
+#       table => 1,
+#     },]
+#   }
+#
+# === Authors:
+#
+# Manfred Pusch <manfred@pusch.cc>
+#
+# === Copyright:
+#
+# Copyright (C) 2016 Manfred Pusch, unless otherwise noted.
+#
+define network::rule (
+  $ipv4_rules = [],
+  $ipv6_rules = [],
+) {
+  # Validate our arrays
+  validate_array($ipv4_rules)
+  validate_array($ipv6_rules)
+
+  include '::network'
+
+  $interface = $name
+
+  if ! empty($ipv4_rules) {
+    file { "rule-${interface}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/rule-${interface}",
+      content => template('network/rule-eth-v4.erb'),
+      before  => File["ifcfg-${interface}"],
+      notify  => Service['network'],
+    }
+  }
+  if ! empty($ipv6_rules) {
+    file { "rule6-${interface}":
+      ensure  => 'present',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      path    => "/etc/sysconfig/network-scripts/rule6-${interface}",
+      content => template('network/rule-eth-v6.erb'),
+      before  => File["ifcfg-${interface}"],
+      notify  => Service['network'],
+    }
+  }
+} # define network::rule

--- a/spec/defines/network_route_spec.rb
+++ b/spec/defines/network_route_spec.rb
@@ -59,4 +59,76 @@ describe 'network::route', :type => 'define' do
     it { should contain_service('network') }
   end
 
+  context 'new parameters v4' do
+    let(:title) { 'eth0' }
+    let :params do {
+      :ipv4_routes => [
+        {
+          'dest'    => '192.168.254.0/24',
+          'gateway' => '192.168.18.1',
+        },{
+          'dest'    => '192.168.253.0/24',
+          'table'   => '1',
+        },{
+          'dest'    => '192.168.252.0/24',
+          'gateway' => '192.168.18.15',
+          'table'   => '2',
+        },
+      ]
+    }
+    end
+    let(:facts) {{ :osfamily => 'RedHat' }}
+    it { should contain_file('route-eth0').with(
+      :ensure => 'present',
+      :mode   => '0644',
+      :owner  => 'root',
+      :group  => 'root',
+      :path   => '/etc/sysconfig/network-scripts/route-eth0'
+    )}
+    it 'should contain File[route-eth0] with contents "192.168.254.0/24 via 192.168.18.1 dev eth0\n192.168.253.0/24 dev eth0 table 1\n192.168.252.0/24 via 192.168.18.15 dev eth0 table 1"' do
+      verify_contents(catalogue, 'route-eth0', [
+        '192.168.254.0/24 via 192.168.18.1 dev eth0',
+        '192.168.253.0/24 dev eth0 table 1',
+        '192.168.252.0/24 via 192.168.18.15 dev eth0 table 2',
+      ])
+    end
+    it { should contain_service('network') }
+  end
+
+  context 'new parameters v6' do
+    let(:title) { 'eth0' }
+    let :params do {
+      :ipv6_routes => [
+        {
+          'dest'    => '0:0:0:0:0:ffff:c0a8:fe00/120',
+          'gateway' => '0:0:0:0:0:ffff:c0a8:1201',
+        },{
+          'dest'    => '0:0:0:0:0:ffff:c0a8:fd00/120',
+          'table'   => '1',
+        },{
+          'dest'    => '0:0:0:0:0:ffff:c0a8:fc00/120',
+          'gateway' => '0:0:0:0:0:ffff:c0a8:120f',
+          'table'   => '2',
+        },
+      ]
+    }
+    end
+    let(:facts) {{ :osfamily => 'RedHat' }}
+    it { should contain_file('route6-eth0').with(
+      :ensure => 'present',
+      :mode   => '0644',
+      :owner  => 'root',
+      :group  => 'root',
+      :path   => '/etc/sysconfig/network-scripts/route6-eth0'
+    )}
+    it 'should contain File[route6-eth0] with contents "0:0:0:0:0:ffff:c0a8:fe00/120 via 0:0:0:0:0:ffff:c0a8:1201 dev eth0\n0:0:0:0:0:ffff:c0a8:fd00/120 dev eth0 table 1\n0:0:0:0:0:ffff:c0a8:fc00/120 via 0:0:0:0:0:ffff:c0a8:120f dev eth0 table 2"' do
+      verify_contents(catalogue, 'route6-eth0', [
+        '0:0:0:0:0:ffff:c0a8:fe00/120 via 0:0:0:0:0:ffff:c0a8:1201 dev eth0',
+        '0:0:0:0:0:ffff:c0a8:fd00/120 dev eth0 table 1',
+        '0:0:0:0:0:ffff:c0a8:fc00/120 via 0:0:0:0:0:ffff:c0a8:120f dev eth0 table 2',
+      ])
+    end
+    it { should contain_service('network') }
+  end
+
 end

--- a/spec/defines/network_rule_spec.rb
+++ b/spec/defines/network_rule_spec.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+
+describe 'network::rule', :type => 'define' do
+
+  context 'new ipv4' do
+    let(:title) { 'eth0' }
+    let :params do {
+      :ipv4_rules => [
+        {
+          'iif'     => 'eth0',
+          'table'   => '1',
+        },{
+          'from'    => '192.168.253.254',
+          'table'   => '1',
+        },{
+          'from'    => '192.168.252.0/24',
+          'reject'  => true,
+        },
+      ]
+    }
+    end
+    let(:facts) {{ :osfamily => 'RedHat' }}
+    it { should contain_file('rule-eth0').with(
+      :ensure => 'present',
+      :mode   => '0644',
+      :owner  => 'root',
+      :group  => 'root',
+      :path   => '/etc/sysconfig/network-scripts/rule-eth0'
+    )}
+    it 'should contain File[rule-eth0] with contents "iif eth0 table 1 \nfrom 192.168.253.254 table 1 \nfrom 192.168.252.0/24 reject "' do
+      verify_contents(catalogue, 'rule-eth0', [
+        'iif eth0 table 1 ',
+        'from 192.168.253.254 table 1 ',
+        'from 192.168.252.0/24 reject ',
+      ])
+    end
+    it { should contain_service('network') }
+  end
+
+  context 'new ipv6' do
+    let(:title) { 'eth0' }
+    let :params do {
+      :ipv6_rules => [
+        {
+          'iif'     => 'eth0',
+          'table'   => '1',
+        },{
+          'from'    => '0:0:0:0:0:ffff:c0a8:fdfe',
+          'table'   => '1',
+        },{
+          'from'    => '0:0:0:0:0:ffff:c0a8:fc00/120',
+          'reject'  => true,
+        },
+      ]
+    }
+    end
+    let(:facts) {{ :osfamily => 'RedHat' }}
+    it { should contain_file('rule6-eth0').with(
+      :ensure => 'present',
+      :mode   => '0644',
+      :owner  => 'root',
+      :group  => 'root',
+      :path   => '/etc/sysconfig/network-scripts/rule6-eth0'
+    )}
+    it 'should contain File[rule6-eth0] with contents "iif eth0 table 1 \nfrom 0:0:0:0:0:ffff:c0a8:fdfe table 1 \nfrom 0:0:0:0:0:ffff:c0a8:fc00/120 reject "' do
+      verify_contents(catalogue, 'rule6-eth0', [
+        'iif eth0 table 1 ',
+        'from 0:0:0:0:0:ffff:c0a8:fdfe table 1 ',
+        'from 0:0:0:0:0:ffff:c0a8:fc00/120 reject ',
+      ])
+    end
+    it { should contain_service('network') }
+  end
+
+end

--- a/templates/route-eth-v4.erb
+++ b/templates/route-eth-v4.erb
@@ -1,0 +1,16 @@
+###
+### File managed by Puppet
+###
+<% if !@ipv4_routes.empty? -%>
+<% [@ipv4_routes].flatten.each do |v4| -%>
+<%= "#{v4["dest"]}" -%>
+<% if v4["gateway"] != nil -%>
+<%= " via #{v4["gateway"]}"  -%>
+<% end -%>
+<%= " dev #{@interface}" -%>
+<% if v4["table"] != nil -%>
+<%= " table #{v4["table"]}" -%>
+<% end -%>
+
+<% end -%>
+<% end -%>

--- a/templates/route-eth-v6.erb
+++ b/templates/route-eth-v6.erb
@@ -1,0 +1,16 @@
+###
+### File managed by Puppet
+###
+<% if !@ipv6_routes.empty? -%>
+<% [@ipv6_routes].flatten.each do |v6| -%>
+<%= "#{v6["dest"]}" -%>
+<% if v6["gateway"] != nil -%>
+<%= " via #{v6["gateway"]}"  -%>
+<% end -%>
+<%= " dev #{@interface}" -%>
+<% if v6["table"] != nil -%>
+<%= " table #{v6["table"]}" -%>
+<% end -%>
+
+<% end -%>
+<% end -%>

--- a/templates/rule-eth-v4.erb
+++ b/templates/rule-eth-v4.erb
@@ -1,0 +1,47 @@
+###
+### File managed by Puppet
+###
+<% if !@ipv4_rules.empty? -%>
+<% [@ipv4_rules].flatten.each do |v4| -%>
+<% if v4["from"] != nil -%>
+<%= "from #{v4["from"]} "  -%>
+<% end -%>
+<% if v4["to"] != nil -%>
+<%= "to #{v4["to"]} "  -%>
+<% end -%>
+<% if v4["tos"] != nil -%>
+<%= "tos #{v4["tos"]} "  -%>
+<% end -%>
+<% if v4["fwmark"] != nil -%>
+<%= "fwmark #{v4["fwmark"]} "  -%>
+<% end -%>
+<% if v4["iif"] != nil -%>
+<%= "iif #{v4["iif"]} "  -%>
+<% end -%>
+<% if v4["oif"] != nil -%>
+<%= "oif #{v4["oif"]} "  -%>
+<% end -%>
+<% if v4["pref"] != nil -%>
+<%= "pref #{v4["pref"]} "  -%>
+<% end -%>
+<% if v4["table"] != nil -%>
+<%= "table #{v4["table"]} "  -%>
+<% end -%>
+<% if v4["nat"] != nil -%>
+<%= "nat #{v4["nat"]} "  -%>
+<% end -%>
+<% if v4["prohibit"] != nil -%>
+<%= "prohibit "  -%>
+<% end -%>
+<% if v4["reject"] != nil -%>
+<%= "reject "  -%>
+<% end -%>
+<% if v4["unreachable"] != nil -%>
+<%= "unreachable "  -%>
+<% end -%>
+<% if v4["realms"] != nil -%>
+<%= "realms #{v4["realms"]} "  -%>
+<% end -%>
+
+<% end -%>
+<% end -%>

--- a/templates/rule-eth-v6.erb
+++ b/templates/rule-eth-v6.erb
@@ -1,0 +1,47 @@
+###
+### File managed by Puppet
+###
+<% if !@ipv6_rules.empty? -%>
+<% [@ipv6_rules].flatten.each do |v6| -%>
+<% if v6["from"] != nil -%>
+<%= "from #{v6["from"]} "  -%>
+<% end -%>
+<% if v6["to"] != nil -%>
+<%= "to #{v6["to"]} "  -%>
+<% end -%>
+<% if v6["tos"] != nil -%>
+<%= "tos #{v6["tos"]} "  -%>
+<% end -%>
+<% if v6["fwmark"] != nil -%>
+<%= "fwmark #{v6["fwmark"]} "  -%>
+<% end -%>
+<% if v6["iif"] != nil -%>
+<%= "iif #{v6["iif"]} "  -%>
+<% end -%>
+<% if v6["oif"] != nil -%>
+<%= "oif #{v6["oif"]} "  -%>
+<% end -%>
+<% if v6["pref"] != nil -%>
+<%= "pref #{v6["pref"]} "  -%>
+<% end -%>
+<% if v6["table"] != nil -%>
+<%= "table #{v6["table"]} "  -%>
+<% end -%>
+<% if v6["nat"] != nil -%>
+<%= "nat #{v6["nat"]} "  -%>
+<% end -%>
+<% if v6["prohibit"] != nil -%>
+<%= "prohibit "  -%>
+<% end -%>
+<% if v6["reject"] != nil -%>
+<%= "reject "  -%>
+<% end -%>
+<% if v6["unreachable"] != nil -%>
+<%= "unreachable "  -%>
+<% end -%>
+<% if v6["realms"] != nil -%>
+<%= "realms #{v6["realms"]} "  -%>
+<% end -%>
+
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Hi and thank's for the module.

I needed to deploy source based policy routing on some of my RHEL hosts, so I extended the module. As always I kept compatibility for existing installations. To use policy routing you first have to add the routes to a specific table:
```
  network::route { 'eth1':
    ipv4_routes => [
      {
        dest    => '10.0.1.0/24',
        table   => '1',
      },
      {
        dest    => 'default',
        gateway => '10.0.1.17',
        table   => '1',
      },
    ]
  }
```
This just adds an ipv4 network and a default route to table 1. Next thing is to add a policy, when to use table 1:
```
  ::network::rule { 'eth1':
    ipv4_rules  => [
      {
        iif     => 'eth1,
        table   => '1',
      },
      {
        from    => '10.0.1.0/24',
        table   => '1',
      }
    ]
  }
```
This policy forces incoming traffic on eth1 and everything with a from address of eth1's subnet into table 1. I have this setup running on a production CEPH cluster for months and it works great. As you can see in the `network::rule` template I also added all the other options, but I haven't had a chance to test everything.

Let me know, what you think about it.