### PR TITLE
Remove old incorrect instruction for promiscuous networking in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,10 +267,6 @@ Normal interface - VLAN - static IPv4:
       netmask   => '255.255.255.0',
     }
 
-Promiscuous interface:
-    To set a static or dynamic interface to promiscuous mode (RedHat only), add:
-      promisc => true
-
 Flush IP addresses:
 
 Network scripts on RHEL7 do not flush IP addresses, so you eventually end up with multiple of them, passing `flush => true` will run `ip addr flush` on given interface before notifying the network service.


### PR DESCRIPTION
An old entry in README.md was left from a previous method of setting up promiscuous networking.