### PR TITLE
Enable using ifscripts for alias resources; allow setting ifcfg resources to absent (remove file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,18 @@ By default, all changes notify the network service, thus triggering a restart of
       restart   => false,
     }
 
+Use ifscripts instead of restarting the network services (alias only):
+
+Alias resources can trigger using the ifdown / ifup scripts instead of doing a full network restart.  They also can be set to ensure => 'absent' to remove the ifcfg-${interface} file (as well as 'up' and 'down'). The ifscripts parameter is a boolean that defaults
+to false.
+
+    network::alias { 'eth0:1':
+      ensure => 'up',
+      ipaddress => '1.2.3.4',
+      netmask   => '255.255.255.0',
+      ifscripts => true,
+    }
+
 Hiera
 -----
 

--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -14,6 +14,7 @@
 #   $zone           - optional
 #   $metric         - optional
 #   $restart        - optional - defaults to true
+#   $ifscripts      - optional
 #
 # === Actions:
 #
@@ -48,12 +49,20 @@ define network::alias (
   $zone = undef,
   $metric = undef,
   $restart = true,
+  $ifscripts = false,
 ) {
   # Validate our data
   if ! is_ip_address($ipaddress) { fail("${ipaddress} is not an IP address.") }
   # Validate our booleans
   validate_bool($noaliasrouting)
   validate_bool($userctl)
+  validate_bool($restart)
+  validate_bool($ifscripts)
+  # Validate our regular expressions
+  $states = [ '^up$', '^down$', '^absent$' ]
+  validate_re($ensure, $states, '$ensure must be "up", "down", or "absent".')
+
+  include '::network'
 
   network_if_base { $title:
     ensure         => $ensure,
@@ -72,5 +81,6 @@ define network::alias (
     zone           => $zone,
     metric         => $metric,
     restart        => $restart,
+    ifscripts      => $ifscripts,
   }
 } # define network::alias

--- a/manifests/alias/range.pp
+++ b/manifests/alias/range.pp
@@ -59,7 +59,7 @@ define network::alias::range (
   validate_bool($arpcheck)
   # Validate our regular expressions
   $states = [ '^up$', '^down$', '^absent$' ]
-  validate_re($ensure, $states, '$ensure must be either "up", "down", or "absent".')
+  validate_re($ensure, $states, '$ensure must be "up", "down", or "absent".')
 
   include '::network'
 

--- a/spec/defines/network_alias_range_spec.rb
+++ b/spec/defines/network_alias_range_spec.rb
@@ -14,7 +14,7 @@ describe 'network::alias::range', :type => 'define' do
     }
     end
     it 'should fail' do
-      expect {should contain_file('ifcfg-bond77-range0')}.to raise_error(Puppet::Error, /\$ensure must be either "up", "down", or "absent"./)
+      expect {should contain_file('ifcfg-bond77-range0')}.to raise_error(Puppet::Error, /\$ensure must be "up", "down", or "absent"./)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,5 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |config|
+  config.before(:all) {Facter.clear}
+end


### PR DESCRIPTION
Create a parameter to allow using the ifup / ifdown scripts for alias resources only (less disruptive than a full network restart).
Allow removal of ifcfg file for aliases when ensure is set to absent.