### PR TITLE
Fixes #104 vlan in device config

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,25 +247,20 @@ Static interface routes (host route):
 
 Normal interface - VLAN - no IP:
 
-    class { 'network::global':
-      vlan => 'yes',
-    }
-
     network::if { 'eth0.330':
       ensure => 'up',
-    }
+      vlan => 'yes',
+   }
 
 Normal interface - VLAN - static IPv4:
-
-    class { 'network::global':
-      vlan => 'yes',
-    }
 
     network::if::static { 'eth0.330':
       ensure    => 'up',
       ipaddress => '10.2.3.248',
       netmask   => '255.255.255.0',
+      vlan => 'yes',
     }
+
 
 Promiscuous interface:
     To set a static or dynamic interface to promiscuous mode (RedHat only), add:
@@ -333,7 +328,6 @@ Notes
 * It is assumed that if you create a bond that you also create the slave interface(s).
 * It is assumed that if you create an alias that you also create the parent interface.
 * network::route requires the referenced device to also be defined via network::if or network::bond.
-* For VLANs to work, `Class['network::global']` must have parameter `vlan` set to `yes`.
 * To enable IPv6 you have to set both `ipv6networking` in `Class['network::global']` to `true` and `ipv6init` in `network::if::static` to `true`.
 
 Issues

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -20,7 +20,7 @@
 #   $ipv6defaultdev - optional - Determines the device to use as the default gateway
 #                                for IPV6 traffic.
 #   $nisdomain      - optional - Configures the NIS domainname.
-#   $vlan           - optional - yes|no to enable VLAN kernel module
+#   $vlan           - optional - yes|no [deprecated] use on device level
 #   $ipv6networking - optional - enables / disables IPv6 globally
 #   $nozeroconf     - optional
 #   $restart        - optional - defaults to true
@@ -43,7 +43,6 @@
 #     ipv6gateway    => '123:4567:89ab:cdef:123:4567:89ab:1',
 #     ipv6defaultdev => 'eth0',
 #     nisdomain      => 'domain.tld',
-#     vlan           => 'yes',
 #     ipv6networking => true,
 #     nozeroconf     => 'yes',
 #     requestreopen  => false,
@@ -65,10 +64,10 @@ class network::global (
   $hostname       = undef,
   $gateway        = undef,
   $gatewaydev     = undef,
+  $vlan           = undef,
   $ipv6gateway    = undef,
   $ipv6defaultdev = undef,
   $nisdomain      = undef,
-  $vlan           = undef,
   $ipv6networking = false,
   $nozeroconf     = undef,
   $restart        = true,

--- a/manifests/if/static.pp
+++ b/manifests/if/static.pp
@@ -29,6 +29,7 @@
 #   $defroute       - optional
 #   $restart        - optional - defaults to true
 #   $arpcheck       - optional - defaults to true
+#   $vlan           - optional - yes|no defaults to no
 #
 # === Actions:
 #
@@ -82,6 +83,7 @@ define network::if::static (
   $metric = undef,
   $restart = true,
   $arpcheck = true,
+  $vlan = undef,
 ) {
   # Validate our data
   if $ipaddress {
@@ -119,6 +121,12 @@ define network::if::static (
   validate_bool($flush)
   validate_bool($arpcheck)
 
+  # Validate our regular expressions
+  if $vlan {
+    $states = [ '^yes$', '^no$' ]
+    validate_re($vlan, $states, '$vlan must be either "yes" or "no".')
+  }
+
   network_if_base { $title:
     ensure          => $ensure,
     ipv6init        => $ipv6init,
@@ -148,5 +156,6 @@ define network::if::static (
     metric          => $metric,
     restart         => $restart,
     arpcheck        => $arpcheck,
+    vlan            => $vlan,
   }
 } # define network::if::static

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class network {
 #   $promisc         - optional - defaults to false
 #   $restart         - optional - defaults to true
 #   $arpcheck        - optional - defaults to true
+#   $vlan            - optional - defaults to 'no'
 #
 # === Actions:
 #
@@ -140,6 +141,7 @@ define network_if_base (
   $promisc         = false,
   $restart         = true,
   $arpcheck        = true,
+  $vlan            = undef,
 ) {
   # Validate our booleans
   validate_bool($noaliasrouting)
@@ -158,6 +160,10 @@ define network_if_base (
   # Validate our regular expressions
   $states = [ '^up$', '^down$' ]
   validate_re($ensure, $states, '$ensure must be either "up" or "down".')
+  if($vlan) {
+    $vlanstates = [ '^yes$', '^no$' ]
+    validate_re($vlan, $vlanstates, '$vlan must be either "yes" or "no".')
+  }
 
   include '::network'
 

--- a/spec/defines/network_if_static_spec.rb
+++ b/spec/defines/network_if_static_spec.rb
@@ -169,6 +169,7 @@ describe 'network::if::static', :type => 'define' do
       :metric       => '10',
       :zone         => 'trusted',
       :arpcheck     => false,
+      :vlan         => 'yes',
     }
     end
     let :facts do {
@@ -212,7 +213,8 @@ describe 'network::if::static', :type => 'define' do
         'DEFROUTE=yes',
         'ZONE=trusted',
         'METRIC=10',
-	'ARPCHECK=no',
+      	'ARPCHECK=no',
+        'VLAN=yes',
         'NM_CONTROLLED=no',
       ])
     end
@@ -225,6 +227,7 @@ describe 'network::if::static', :type => 'define' do
       :ensure    => 'up',
       :ipaddress => '1.2.3.4',
       :netmask   => '255.255.255.0',
+      :vlan      => 'yes',
     }
     end
     let :facts do {
@@ -250,6 +253,7 @@ describe 'network::if::static', :type => 'define' do
         'TYPE=Ethernet',
         'IPADDR=1.2.3.4',
         'NETMASK=255.255.255.0',
+        'VLAN=yes',
         'NM_CONTROLLED=no',
       ])
     end

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -70,4 +70,6 @@ check_link_down() {
 <% end -%>
 <% if !@arpcheck %>ARPCHECK=no
 <% end -%>
+<% if @vlan %>VLAN=<%= @vlan %>
+<% end -%>
 NM_CONTROLLED=no


### PR DESCRIPTION
I have reworked the already proposed but now retired [PR #87](https://github.com/razorsedge/puppet-network/pull/87), added proper documentation and hope to have fixed Issue #104 with that.

Important changes:

- $vlan can now be set on interface level
- $vlan can still be set globally but is removed from the docs and marked as deprecated in the class