### PR TITLE
Add support for DHCPV6C

### DIFF
--- a/manifests/bond/dynamic.pp
+++ b/manifests/bond/dynamic.pp
@@ -37,6 +37,9 @@
 #
 define network::bond::dynamic (
   $ensure,
+  $ipv6init = false,
+  $ipv6autoconf = false,
+  $ipv6dhcpv6c = false,
   $mtu = undef,
   $ethtool_opts = undef,
   $bonding_opts = 'miimon=100',
@@ -56,8 +59,9 @@ define network::bond::dynamic (
     gateway      => '',
     macaddress   => '',
     bootproto    => 'dhcp',
-    ipv6address  => '',
-    ipv6gateway  => '',
+    ipv6init     => $ipv6init,
+    ipv6autoconf => $ipv6autoconf,
+    ipv6dhcpv6c  => $ipv6dhcpv6c,
     mtu          => $mtu,
     ethtool_opts => $ethtool_opts,
     bonding_opts => $bonding_opts,

--- a/manifests/bridge/dynamic.pp
+++ b/manifests/bridge/dynamic.pp
@@ -38,6 +38,9 @@
 define network::bridge::dynamic (
   $ensure,
   $bootproto = 'dhcp',
+  $ipv6init = false,
+  $ipv6autoconf = false,
+  $ipv6dhcpv6c = false,
   $userctl = false,
   $stp = false,
   $delay = '30',

--- a/manifests/if/dynamic.pp
+++ b/manifests/if/dynamic.pp
@@ -47,6 +47,9 @@
 #
 define network::if::dynamic (
   $ensure,
+  $ipv6init        = false,
+  $ipv6autoconf    = false,
+  $ipv6dhcpv6c     = false,
   $macaddress      = undef,
   $manage_hwaddr   = true,
   $bootproto       = 'dhcp',
@@ -83,6 +86,9 @@ define network::if::dynamic (
     ipaddress       => '',
     netmask         => '',
     gateway         => '',
+    ipv6init        => $ipv6init,
+    ipv6autoconf    => $ipv6autoconf,
+    ipv6dhcpv6c     => $ipv6dhcpv6c,
     macaddress      => $macaddy,
     manage_hwaddr   => $manage_hwaddr,
     bootproto       => $bootproto,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,6 +116,7 @@ define network_if_base (
   $ipv6gateway     = undef,
   $ipv6init        = false,
   $ipv6autoconf    = false,
+  $ipv6dhcpv6c     = false,
   $ipv6secondaries = undef,
   $bootproto       = 'none',
   $userctl         = false,
@@ -148,6 +149,7 @@ define network_if_base (
   validate_bool($peerdns)
   validate_bool($ipv6init)
   validate_bool($ipv6autoconf)
+  validate_bool($ipv6dhcpv6c)
   validate_bool($ipv6peerdns)
   validate_bool($check_link_down)
   validate_bool($manage_hwaddr)

--- a/templates/ifcfg-br.erb
+++ b/templates/ifcfg-br.erb
@@ -12,6 +12,10 @@ TYPE=Bridge
 <% if @gateway %>GATEWAY=<%= @gateway %>
 <% end -%>
 <% if @ipv6init %>IPV6INIT=yes
+<% if !@ipv6autoconf %>IPV6_AUTOCONF=no
+<% end -%>
+<% if @ipv6dhcpv6c %>DHCPV6C=yes
+<% end -%>
 <% if @ipv6address %>IPV6ADDR=<%= @ipv6address %>
 <% end -%>
 <% if @ipv6gateway %>IPV6_DEFAULTGW=<%= @ipv6gateway %>

--- a/templates/ifcfg-eth.erb
+++ b/templates/ifcfg-eth.erb
@@ -39,6 +39,9 @@ IPV6INIT=yes
 <% if !@ipv6autoconf %>IPV6_AUTOCONF=no
 <% else %>IPV6_AUTOCONF=yes
 <% end -%>
+<% if !@ipv6dhcpv6c %>DHCPV6C=no
+<% else %>DHCPV6C=yes
+<% end -%>
 <% if @ipv6address %>IPV6ADDR=<%= @ipv6address %>
 <% end -%>
 <% if @ipv6gateway %>IPV6_DEFAULTGW=<%= @ipv6gateway %>


### PR DESCRIPTION
To support dualstack machines with network configured by DHCPv4 and DHCPv6 it is necessary to extend *::dynamic defines and corresponding templates with DHCPV6C