### PR TITLE
Add routes to the active routing table

### DIFF
--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -67,6 +67,18 @@ define network::route (
     before  => File["ifcfg-${interface}"],
   }
 
+  $routes = zip($ipaddress, $netmask, $gateway)
+  $routes.each |Array $route|{
+    $ipaddress = $route[0]
+    $netmask   = $route[1]
+    $gateway   = $route[2]
+
+    exec { "route: $route":
+      command => "/usr/sbin/ip route add $ipaddress/$netmask via $gateway dev $interface",
+      unless  => "/usr/sbin/ip route show $ipaddress/$netmask via $gateway dev $interface | grep \\.\\*",
+    }
+  }
+
   if $restart {
     File["route-${interface}"] {
       notify  => Service['network'],

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -67,7 +67,7 @@ define network::route (
     before  => File["ifcfg-${interface}"],
   }
 
-  $routes = zip($ipaddress, zip($netmask, $gateway)).map |x| {x.flatten}
+  $routes = map(zip($ipaddress, zip($netmask, $gateway))) |$x| {$x.flatten}
   $routes.each |Array $route|{
     $ipaddress = $route[0]
     $netmask   = $route[1]

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -73,7 +73,7 @@ define network::route (
     $netmask   = $route[1]
     $gateway   = $route[2]
 
-    exec { "route: $route":
+    exec { "route: ${route}":
       command => "/usr/sbin/ip route add ${ipaddress}/${netmask} via ${gateway} dev ${interface}",
       unless  => "/usr/sbin/ip route show ${ipaddress}/${netmask} via ${gateway} dev ${interface} | grep \\.\\*",
     }

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -67,7 +67,7 @@ define network::route (
     before  => File["ifcfg-${interface}"],
   }
 
-  $routes = zip($ipaddress, $netmask, $gateway)
+  $routes = zip($ipaddress, zip($netmask, $gateway)).map |x| {x.flatten}
   $routes.each |Array $route|{
     $ipaddress = $route[0]
     $netmask   = $route[1]

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -74,8 +74,8 @@ define network::route (
     $gateway   = $route[2]
 
     exec { "route: $route":
-      command => "/usr/sbin/ip route add $ipaddress/$netmask via $gateway dev $interface",
-      unless  => "/usr/sbin/ip route show $ipaddress/$netmask via $gateway dev $interface | grep \\.\\*",
+      command => "/usr/sbin/ip route add ${ipaddress}/${netmask} via ${gateway} dev ${interface}",
+      unless  => "/usr/sbin/ip route show ${ipaddress}/${netmask} via ${gateway} dev ${interface} | grep \\.\\*",
     }
   }
 


### PR DESCRIPTION
Add routes to the active routing table if they don't exist in the active routing table even if they've already been added to the route-<interface> network-script.